### PR TITLE
avoid re-defining session with token auth

### DIFF
--- a/binder/ECCO.ipynb
+++ b/binder/ECCO.ipynb
@@ -252,7 +252,7 @@
     "    token = json.load(fp)\n",
     "\n",
     "# pass Token Authorization to a new Session.\n",
-    "my_session = create_session(session_kwargs=token)"
+    "my_session = create_session(use_cache=True, session_kwargs=token)"
    ]
   },
   {
@@ -368,7 +368,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "new_urls = [url.replace(\"https\", \"dap4\")+CE for url in granules_urls]\n",
+    "new_urls = [url.replace(\"https\", \"dap4\") + CE for url in granules_urls]\n",
     "new_urls[:4]"
    ]
   },
@@ -385,21 +385,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6c3b123c-fad5-420d-b8fd-eb27eb903fd7",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "cached_session = create_session(use_cache=True, session_kwargs=token)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
    "id": "af25e868-8e04-4a18-aff7-f1bfaec4c00b",
    "metadata": {},
    "outputs": [],
    "source": [
-    "cached_session"
+    "my_session"
    ]
   },
   {
@@ -410,7 +400,7 @@
    "outputs": [],
    "source": [
     "# clear just in case\n",
-    "cached_session.cache.clear()"
+    "my_session.cache.clear()"
    ]
   },
   {
@@ -421,7 +411,7 @@
    "outputs": [],
    "source": [
     "%%time\n",
-    "consolidate_metadata(new_urls, cached_session)"
+    "consolidate_metadata(new_urls, my_session)"
    ]
   },
   {
@@ -431,7 +421,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "cached_session.cache.urls()[:10]"
+    "my_session.cache.urls()[:10]"
    ]
   },
   {
@@ -452,7 +442,7 @@
    "outputs": [],
    "source": [
     "%%time\n",
-    "ds = xr.open_mfdataset(new_urls, engine='pydap', session=cached_session, parallel=True, combine='nested', concat_dim='time')"
+    "ds = xr.open_mfdataset(new_urls, engine='pydap', session=my_session, parallel=True, combine='nested', concat_dim='time')"
    ]
   },
   {


### PR DESCRIPTION
- [x] Last  change. Somehow there was an issue when re-defining the cached_session object a 2 time within a notebook, when token was being loaded from .json file. 