### PR TITLE
Update tutorials

### DIFF
--- a/binder/CallipsoL2_access.ipynb
+++ b/binder/CallipsoL2_access.ipynb
@@ -9,74 +9,22 @@
     "\n",
     " <span style='color:#ff6666'><font size=\"5\"> **Requirements**\n",
     "1. <font size=\"3\"> EDL authentication (username/password)\n",
-    "2. <font size=\"3\"> Generate a Bearer Token.\n",
-    "3. <font size=\"3\"> Get Notebook from NASA-tutorial Github repository\n",
-    "4. <font size=\"3\"> Get `environment.yml` file and install conda environment to run notebook.\n",
+    "2. <font size=\"3\"> Run Notebook in binder from NASA-tutorial Github repository, or\n",
+    "3. <font size=\"3\"> Get `environment.yml` file and install conda environment to run notebook.\n",
     "\n",
     "\n",
     " <span style='color:#ff6666'><font size=\"5\"> **Objectives**\n",
-    "### Basics\n",
-    "- <font size=\"3\"> Brief Introduction to <span style='color:#ff6666'>**OPeNDAP**</span> (i.e. **dap2** vs **dap4**). \n",
-    "- <font size=\"3\"> How to find <span style='color:#ff6666'>**OPeNDAP**</span> URLs.\n",
-    "- <font size=\"3\"> Inspecting metadata (differences between **browser** / <span style='color:#ff6666'>**pydap**</span> and **Xarray**).\n",
-    "- <font size=\"3\"> **Naive approach**: access data from a url using **Xarray** + <span style='color:#ff6666'>**pydap**<span style='color:black'>. Here we demonstrate different ways to authenticate.\n",
-    "\n",
-    "### Subset a remote file\n",
-    "\n",
-    "- <font size=\"3\">**a)** By Variables\n",
-    "- <font size=\"3\">**b)** By Spatial selection\n",
-    "\n",
-    "### Subset multiple remote files\n",
-    "\n",
-    "- <font size=\"3\"> **a)** Naive approaches.\n",
-    "- <font size=\"3\"> **b)** Streaming data\n",
-    "\n",
-    "## Appendix: Using curl\n"
+    "- <font size=\"3\"> Inspecting metadata.\n",
+    "- <font size=\"3\"> Subset by variable names.\n",
+    "-  <font size=\"3\"> Subset by spatial selection.\n",
+    "- <font size=\"3\"> Streaming data into local file\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
-   "id": "4d7169fc-79ab-4152-954d-a1be77ca55df",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-02-13T17:49:13.978856Z",
-     "iopub.status.busy": "2026-02-13T17:49:13.978491Z",
-     "iopub.status.idle": "2026-02-13T17:49:13.982854Z",
-     "shell.execute_reply": "2026-02-13T17:49:13.981907Z",
-     "shell.execute_reply.started": "2026-02-13T17:49:13.978822Z"
-    },
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "import os, sys\n",
-    "if sys.platform.startswith(\"linux\"):\n",
-    "    # fattrs is missing even though it is installed. issue with libraries\n",
-    "    # 1. Remove system HDF5 from library lookup path\n",
-    "    os.environ.pop(\"LD_LIBRARY_PATH\", None)\n",
-    "    # 2. Prepend conda environment's lib & bin paths\n",
-    "    conda_lib = sys.exec_prefix + \"/lib\"\n",
-    "    conda_bin = sys.exec_prefix + \"/bin\"\n",
-    "    os.environ[\"PATH\"] = conda_bin + \":\" + os.environ[\"PATH\"]\n",
-    "    os.environ[\"LD_LIBRARY_PATH\"] = conda_lib\n",
-    "    \n",
-    "import warnings\n",
-    "warnings.filterwarnings('ignore')\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "740c000d-5314-4aaf-81a5-d70d1e79f9fe",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-02-13T17:49:51.956100Z",
-     "iopub.status.busy": "2026-02-13T17:49:51.955904Z",
-     "iopub.status.idle": "2026-02-13T17:49:51.958988Z",
-     "shell.execute_reply": "2026-02-13T17:49:51.958258Z",
-     "shell.execute_reply.started": "2026-02-13T17:49:51.956086Z"
-    },
     "tags": []
    },
    "outputs": [],
@@ -84,43 +32,9 @@
     "import xarray as xr\n",
     "import datetime as dt\n",
     "import earthaccess\n",
-    "import pydap\n",
-    "import requests\n",
-    "import matplotlib.pyplot as plt\n",
     "# import pydap-specific tools\n",
-    "from pydap.net import create_session\n",
-    "from pydap.client import get_cmr_urls, consolidate_metadata, open_url\n",
+    "from pydap.client import get_cmr_urls, open_url\n",
     "from pydap.client import to_netcdf as dap_to_netcdf"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "id": "b807a4db-c4f6-40f6-9dab-43e398b2edb8",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-02-13T17:49:42.245933Z",
-     "iopub.status.busy": "2026-02-13T17:49:42.245490Z",
-     "iopub.status.idle": "2026-02-13T17:49:42.251180Z",
-     "shell.execute_reply": "2026-02-13T17:49:42.250447Z",
-     "shell.execute_reply.started": "2026-02-13T17:49:42.245918Z"
-    },
-    "tags": []
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'3.5.9.dev41+g436dd71c5'"
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "pydap.__version__"
    ]
   },
   {
@@ -135,29 +49,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "c7bdc702-f426-4b0a-a49f-2649ecdc7c18",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-02-13T17:49:55.877303Z",
-     "iopub.status.busy": "2026-02-13T17:49:55.877115Z",
-     "iopub.status.idle": "2026-02-13T17:49:56.514796Z",
-     "shell.execute_reply": "2026-02-13T17:49:56.514014Z",
-     "shell.execute_reply.started": "2026-02-13T17:49:55.877290Z"
-    },
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "################################################ \n",
-      " We found a total of  117 OPeNDAP URLS!!!\n",
-      "################################################\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "Callipso_L2_ccid = \"C3463063995-LARC_CLOUD\" # \n",
     "time_range = [dt.datetime(2023, 5, 15), dt.datetime(2023, 5, 20)] # One month of data\n",
@@ -165,53 +62,6 @@
     "cmr_urls = get_cmr_urls(ccid=Callipso_L2_ccid, time_range=time_range, limit=1000) # you can incread the limit of results\n",
     "\n",
     "print(\"################################################ \\n We found a total of \", len(cmr_urls), \"OPeNDAP URLS!!!\\n################################################\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "id": "4c4fd12d-ef2f-4739-b016-94e821cc89e2",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-02-13T17:49:57.988749Z",
-     "iopub.status.busy": "2026-02-13T17:49:57.988457Z",
-     "iopub.status.idle": "2026-02-13T17:49:57.992016Z",
-     "shell.execute_reply": "2026-02-13T17:49:57.991347Z",
-     "shell.execute_reply.started": "2026-02-13T17:49:57.988723Z"
-    },
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "# def get_opendap_urls(concept_id, time_range, _session=None):\n",
-    "#     \"\"\"\n",
-    "#     Queries NASA's `Common Metadata Repository` to identify all OPeNDAP URLS\n",
-    "#     given collection concept ID and temporal time range.\n",
-    "#     \"\"\"\n",
-    "#     cmr_url = 'https://cmr.earthdata.nasa.gov/search/granules'\n",
-    "#     if not _session:\n",
-    "#         _session = requests.Session() \n",
-    "#     cmr_response = _session.get(cmr_url, params={'concept_id': concept_id,'temporal': time_range,'page_size': 500}, headers={'Accept': 'application/json'})\n",
-    "#     granules = cmr_response.json()['feed']['entry']\n",
-    "#     granules_urls = []\n",
-    "    \n",
-    "#     # Filter and only retain the OPeNDAP URLs\n",
-    "#     for granule in granules:\n",
-    "#         item = next((item['href'] for item in granule['links'] if \"opendap\" in item[\"href\"]), None)\n",
-    "#         if item != None:\n",
-    "#             granules_urls.append(item)\n",
-    "#     return granules_urls\n",
-    "\n",
-    "# start_date =  dt.datetime(2023, 5, 15)\n",
-    "# end_date =dt.datetime(2023, 5, 20)\n",
-    "\n",
-    "# print(start_date, end_date,sep='\\n')\n",
-    "\n",
-    "# dt_format = '%Y-%m-%dT%H:%M:%SZ' # format requirement for datetime search\n",
-    "# temporal_str = start_date.strftime(dt_format) + ',' + end_date.strftime(dt_format)\n",
-    "\n",
-    "# cmr_urls = get_opendap_urls(Callipso_L2_ccid, temporal_str)\n",
-    "# print(len(cmr_urls))"
    ]
   },
   {
@@ -224,34 +74,6 @@
    "outputs": [],
    "source": [
     "cmr_urls[0]"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "8d9882ef-e8cd-49f8-b627-026047124459",
-   "metadata": {},
-   "source": [
-    "# Inspecting Metadata\n",
-    "\n",
-    "<span style='font-family:serif'> <font size=\"5.5\"><span style='color:#0066cc'> **Understanding DAP4**\n",
-    "\n",
-    "<div style=\"text-align:center\">\n",
-    "<img src=\"figures/DAP4vsDAP2.png\" alt=\"drawing\" width=\"750\"/>    \n",
-    "</div>\n",
-    "\n",
-    "\n",
-    "### Basic Data Exploration\n",
-    "\n",
-    "<font size=\"3.5\">To inspect the metadata of a remote OPeNDAP URL (variables in the file), you :\n",
-    "\n",
-    "* <font size=\"3.5\"> Append a `.dmr` at the end of the URL\n",
-    "* <font size=\"3.5\"> Open on a browser.\n",
-    "* <font size=\"3.5\"> Useful when interested in subseting by variables for example.\n",
-    "\n",
-    "For example:\n",
-    "    \n",
-    "https://opendap.earthdata.nasa.gov/collections/C3463063995-LARC_CLOUD/granules/CAL_LID_L2_01kmCLay-Standard-V5-00.2023-05-15T23-26-01ZD.hdf\n",
-    "\n"
    ]
   },
   {
@@ -272,16 +94,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "2725988f-618e-4ed4-879c-3adc0c4771e4",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-02-13T17:50:08.858796Z",
-     "iopub.status.busy": "2026-02-13T17:50:08.858560Z",
-     "iopub.status.idle": "2026-02-13T17:50:16.927525Z",
-     "shell.execute_reply": "2026-02-13T17:50:16.926590Z",
-     "shell.execute_reply.started": "2026-02-13T17:50:08.858780Z"
-    },
     "tags": []
    },
    "outputs": [],
@@ -289,8 +104,7 @@
     "auth = earthaccess.login(strategy=\"netrc\", persist=True) # you will be promted to add your EDL credentials\n",
     "\n",
     "# pass Token Authorization to a new Session.\n",
-    "my_session = create_session(session=auth.get_session())\n",
-    "# my_session = requests.session()"
+    "my_session = session=auth.get_session()"
    ]
   },
   {
@@ -322,299 +136,27 @@
    "outputs": [],
    "source": [
     "%%time\n",
-    "pyds = open_url(cmr_urls[0], protocol=\"dap4\", session=my_session)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "da46dc24-4989-4e0d-9ddb-bb4b93feaef1",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
+    "pyds = open_url(cmr_urls[0], protocol=\"dap4\", session=my_session)\n",
     "pyds.tree()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
-   "id": "9274139d-3312-4a38-9707-4053f0247233",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-02-13T17:50:35.877985Z",
-     "iopub.status.busy": "2026-02-13T17:50:35.877636Z",
-     "iopub.status.idle": "2026-02-13T17:54:24.106343Z",
-     "shell.execute_reply": "2026-02-13T17:54:24.105497Z",
-     "shell.execute_reply.started": "2026-02-13T17:50:35.877957Z"
-    },
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "nbytes = []\n",
-    "for url in cmr_urls:\n",
-    "    pyds = open_url(url, protocol=\"dap4\", session=my_session)\n",
-    "    nbytes.append(pyds.nbytes)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 1,
-   "id": "48a20365-c795-41cd-a122-2386da3e4b0b",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-03-10T23:46:18.780036Z",
-     "iopub.status.busy": "2026-03-10T23:46:18.779775Z",
-     "iopub.status.idle": "2026-03-10T23:46:18.911787Z",
-     "shell.execute_reply": "2026-03-10T23:46:18.911008Z",
-     "shell.execute_reply.started": "2026-03-10T23:46:18.780014Z"
-    },
-    "tags": []
-   },
-   "outputs": [
-    {
-     "ename": "NameError",
-     "evalue": "name 'nbytes' is not defined",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
-      "\u001b[31mNameError\u001b[39m                                 Traceback (most recent call last)",
-      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[1]\u001b[39m\u001b[32m, line 1\u001b[39m\n\u001b[32m----> \u001b[39m\u001b[32m1\u001b[39m \u001b[38;5;28msum\u001b[39m(\u001b[43mnbytes\u001b[49m)\n",
-      "\u001b[31mNameError\u001b[39m: name 'nbytes' is not defined"
-     ]
-    }
-   ],
-   "source": [
-    "sum(nbytes)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "6d3b2e98-5050-4e46-85e0-f977efc69174",
-   "metadata": {},
-   "source": [
-    "<span style='font-family:serif'> <font size=\"5\"><span style='color:#0066cc'> **Recommended Worklow for Streaming Data**\n",
-    "\n",
-    "\n",
-    "* <font size=\"3.5\"><span style='color:#0066cc'> **Data Exploration**</span>: `Xarray + PyDAP`. When interested in visualizing one or two variables. Identify regions of interest (interactively).\n",
-    "\n",
-    "However, if the goal is to stream data via OPeNDAP, Xarray+opendap requires extra logic to get the **best performance** that is stil subpar compared to **talking to the server directly**\n",
-    "\n",
-    "\n",
-    "* <font size=\"3.5\"><span style='color:#0066cc'> **Streaming a Data Subset**</span>: Pure PyDAP to parallelize direct server (subset) requests. See below:\n",
-    "\n",
-    "\n"
-   ]
-  },
-  {
-   "cell_type": "code",
    "execution_count": null,
-   "id": "6879445c-cae7-4b7b-a729-f5f7e4e8c805",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 13,
    "id": "5b87a6c6-6bb3-4c3b-b1a1-2f61c8ff5eea",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-02-13T18:00:04.171747Z",
-     "iopub.status.busy": "2026-02-13T18:00:04.171534Z",
-     "iopub.status.idle": "2026-02-13T18:00:04.175169Z",
-     "shell.execute_reply": "2026-02-13T18:00:04.174489Z",
-     "shell.execute_reply.started": "2026-02-13T18:00:04.171732Z"
-    },
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "?dap4.ce=/Lidar_Surface_Detection;/Ocean_Derived_Column_Optical_Depth;/Lidar_Data_Altitudes;/Profile_ID;/Latitude;/Longitude;/Profile_Time;/Profile_UTC_Time;/Day_Night_Flag;/Tropopause_Height;/Tropopause_Temperature;/Snow_Ice_Surface_Type;/Opacity_Flag\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "output_path = \"/home/idies/workspace/Temporary/Mikejmnez/scratch/data/\"\n",
+    "output_path = \"data/\"\n",
     "\n",
-    "# keep_variables = [\"Lidar_Data_Altitudes\", \"Profile_ID\", \"Latitude\", \"Longitude\",\n",
-    "#                   \"Profile_Time\", \"Profile_UTC_Time\", \"Tropopause_Height\", \"Tropopause_Temperature\", \n",
-    "#                   \"Ocean_Derived_Column_Optical_Depth\", \"Lidar_Surface_Detection\"]\n",
     "keep_variables = [\n",
     "    '/Lidar_Surface_Detection', \"/Ocean_Derived_Column_Optical_Depth\",\n",
     "    \"/Lidar_Data_Altitudes\", \"/Profile_ID\", \"/Latitude\", \"/Longitude\", \n",
     "    \"/Profile_Time\", \"/Profile_UTC_Time\", \"/Day_Night_Flag\", \"/Tropopause_Height\", \n",
     "    \"/Tropopause_Temperature\",\"/Snow_Ice_Surface_Type\", \"/Opacity_Flag\", \n",
-    "]\n",
-    "dap4ce = \"?dap4.ce=\"+\";\".join(keep_variables)\n",
-    "print(dap4ce)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "9157e777-de43-448f-a7f4-a17c4907261e",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "cmr_urls[0]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "2b654da8-3b02-4448-b0a5-bba810b0a84d",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "cmr_urls[1]"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "71e11f81-b17f-416a-8342-7da78035ae81",
-   "metadata": {
-    "tags": []
-   },
-   "source": [
-    "# Single File\n",
-    "\n",
-    "### OPeNDAP + pydap-only logic\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "f856e281-d1c5-4004-a0bf-45415eb827a3",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-02-09T22:55:41.551764Z",
-     "iopub.status.busy": "2026-02-09T22:55:41.551538Z",
-     "iopub.status.idle": "2026-02-09T22:55:41.554773Z",
-     "shell.execute_reply": "2026-02-09T22:55:41.553942Z",
-     "shell.execute_reply.started": "2026-02-09T22:55:41.551749Z"
-    }
-   },
-   "source": [
-    "### metadata only"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "6901027f-8483-4bb7-9ff3-2c067ed7a228",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "%%time\n",
-    "pyds = open_url(cmr_urls[0].replace(\"https\", \"dap4\")+dap4ce, session=my_session)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "baac9930-71a8-4f56-acd4-5c0134e3ea7f",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "pyds.tree()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "11c50815-bd69-4b51-9116-3498fb3cc591",
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "b840dab4-ec1f-4272-963e-13dbeeffcd4f",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "%%time\n",
-    "to_netcdf(cmr_urls[0], session=my_session, keep_variables=keep_variables, output_path=output_path)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "40d812ff-c268-4a86-b18b-8e1f939f2100",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "# dT = xr.open_datatree(output_path+\"/CAL_LID_L2_01kmCLay-Standard-V5-00.2023-05-15T23-26-01ZD.nc4\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "1ef7f417-0f3a-434b-9a57-72537debaef8",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "# dT"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "57767946-f91c-4d8d-966a-7f87dc19a1d8",
-   "metadata": {},
-   "source": [
-    "### xarray approach\n",
-    "\n",
-    "- 2-step process: \n",
-    "1. Create an Xarray Dataset object.\n",
-    "2. Download as file of choice.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "e88a0682-0835-430a-8922-3e43b7cd2847",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "%%time\n",
-    "ds = xr.open_datatree(cmr_urls[0].replace(\"https\", \"dap4\")+dap4ce, session=my_session, engine='pydap')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "50c5356d-4430-4193-9675-4b8f4f743ce5",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "%%time\n",
-    "ds.to_netcdf(output_path+'/single_download.nc4')"
+    "]"
    ]
   },
   {
@@ -624,63 +166,21 @@
     "tags": []
    },
    "source": [
-    "### Multiple downloads\n",
-    "\n",
-    "- OPenDAP & pydap-only approach"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 14,
-   "id": "1c9d5e9e-0228-406c-81db-6318169e138f",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-02-13T18:00:37.956127Z",
-     "iopub.status.busy": "2026-02-13T18:00:37.955791Z",
-     "iopub.status.idle": "2026-02-13T18:02:21.409005Z",
-     "shell.execute_reply": "2026-02-13T18:02:21.408229Z",
-     "shell.execute_reply.started": "2026-02-13T18:00:37.956100Z"
-    },
-    "tags": []
-   },
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "bc233a9ddf264d5c99a1a25b414ed527",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "Downloading (117 remote files):   0%|          | 0/117 [00:00<?, ?url/s]"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "CPU times: user 161 ms, sys: 30.5 ms, total: 191 ms\n",
-      "Wall time: 1min 43s\n"
-     ]
-    }
-   ],
-   "source": [
-    "%%time\n",
-    "dap_to_netcdf(cmr_urls, session=my_session, keep_variables=keep_variables, output_path=output_path)"
+    "### Stream data"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a2724c6e-e182-48c2-8ec2-400f2e3d1f11",
+   "id": "1c9d5e9e-0228-406c-81db-6318169e138f",
    "metadata": {
     "tags": []
    },
    "outputs": [],
-   "source": []
+   "source": [
+    "%%time\n",
+    "dap_to_netcdf(cmr_urls, session=my_session, keep_variables=keep_variables, output_path=output_path)"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -693,75 +193,20 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2ce9e542-d57e-4229-9454-129d57c51a82",
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 16,
    "id": "93fa4be6-28a7-441f-8f79-f1f2c1666e90",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-02-13T18:04:23.461353Z",
-     "iopub.status.busy": "2026-02-13T18:04:23.461041Z",
-     "iopub.status.idle": "2026-02-13T18:04:23.502549Z",
-     "shell.execute_reply": "2026-02-13T18:04:23.501720Z",
-     "shell.execute_reply.started": "2026-02-13T18:04:23.461336Z"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "ds = xr.open_datatree(output_path+\"CAL_LID_L2_01kmCLay-Standard-V5-00.2023-05-17T15-41-01ZN.nc4\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 20,
-   "id": "0e244f79-a6b1-4a72-b77a-d9b3b831f607",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-02-13T18:07:08.188794Z",
-     "iopub.status.busy": "2026-02-13T18:07:08.188440Z",
-     "iopub.status.idle": "2026-02-13T18:07:08.194838Z",
-     "shell.execute_reply": "2026-02-13T18:07:08.194063Z",
-     "shell.execute_reply.started": "2026-02-13T18:07:08.188768Z"
-    },
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "from pathlib import Path\n",
-    "\n",
-    "data_dir = Path(output_path)  # <-- change this\n",
-    "files = sorted(data_dir.glob(\"*.nc4\"))  "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "20d6d9a8-18bc-4681-ac22-44908b6b2b1c",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "177c4ea4-7284-4b2d-84f2-6308bd464660",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "dt = xr.open_datatree(output_path+\"CAL_LID_L2_01kmCLay-Standard-V5-00.2023-05-17T15-41-01ZN.nc4\")\n",
+    "dt"
+   ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.13",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "earthdata2026"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -773,7 +218,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.12"
+   "version": "3.12.13"
   }
  },
  "nbformat": 4,

--- a/binder/CallipsoL2_access.ipynb
+++ b/binder/CallipsoL2_access.ipynb
@@ -1,0 +1,781 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "dd1d5518-f9a5-4a7f-a5fc-16d6a7394ee4",
+   "metadata": {},
+   "source": [
+    "<span style='color:#0066cc'> <span style='font-family:serif'> <font size=\"15\"> **Accessing L2 data (CALLIPSO)**\n",
+    "\n",
+    " <span style='color:#ff6666'><font size=\"5\"> **Requirements**\n",
+    "1. <font size=\"3\"> EDL authentication (username/password)\n",
+    "2. <font size=\"3\"> Generate a Bearer Token.\n",
+    "3. <font size=\"3\"> Get Notebook from NASA-tutorial Github repository\n",
+    "4. <font size=\"3\"> Get `environment.yml` file and install conda environment to run notebook.\n",
+    "\n",
+    "\n",
+    " <span style='color:#ff6666'><font size=\"5\"> **Objectives**\n",
+    "### Basics\n",
+    "- <font size=\"3\"> Brief Introduction to <span style='color:#ff6666'>**OPeNDAP**</span> (i.e. **dap2** vs **dap4**). \n",
+    "- <font size=\"3\"> How to find <span style='color:#ff6666'>**OPeNDAP**</span> URLs.\n",
+    "- <font size=\"3\"> Inspecting metadata (differences between **browser** / <span style='color:#ff6666'>**pydap**</span> and **Xarray**).\n",
+    "- <font size=\"3\"> **Naive approach**: access data from a url using **Xarray** + <span style='color:#ff6666'>**pydap**<span style='color:black'>. Here we demonstrate different ways to authenticate.\n",
+    "\n",
+    "### Subset a remote file\n",
+    "\n",
+    "- <font size=\"3\">**a)** By Variables\n",
+    "- <font size=\"3\">**b)** By Spatial selection\n",
+    "\n",
+    "### Subset multiple remote files\n",
+    "\n",
+    "- <font size=\"3\"> **a)** Naive approaches.\n",
+    "- <font size=\"3\"> **b)** Streaming data\n",
+    "\n",
+    "## Appendix: Using curl\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "4d7169fc-79ab-4152-954d-a1be77ca55df",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-02-13T17:49:13.978856Z",
+     "iopub.status.busy": "2026-02-13T17:49:13.978491Z",
+     "iopub.status.idle": "2026-02-13T17:49:13.982854Z",
+     "shell.execute_reply": "2026-02-13T17:49:13.981907Z",
+     "shell.execute_reply.started": "2026-02-13T17:49:13.978822Z"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import os, sys\n",
+    "if sys.platform.startswith(\"linux\"):\n",
+    "    # fattrs is missing even though it is installed. issue with libraries\n",
+    "    # 1. Remove system HDF5 from library lookup path\n",
+    "    os.environ.pop(\"LD_LIBRARY_PATH\", None)\n",
+    "    # 2. Prepend conda environment's lib & bin paths\n",
+    "    conda_lib = sys.exec_prefix + \"/lib\"\n",
+    "    conda_bin = sys.exec_prefix + \"/bin\"\n",
+    "    os.environ[\"PATH\"] = conda_bin + \":\" + os.environ[\"PATH\"]\n",
+    "    os.environ[\"LD_LIBRARY_PATH\"] = conda_lib\n",
+    "    \n",
+    "import warnings\n",
+    "warnings.filterwarnings('ignore')\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "740c000d-5314-4aaf-81a5-d70d1e79f9fe",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-02-13T17:49:51.956100Z",
+     "iopub.status.busy": "2026-02-13T17:49:51.955904Z",
+     "iopub.status.idle": "2026-02-13T17:49:51.958988Z",
+     "shell.execute_reply": "2026-02-13T17:49:51.958258Z",
+     "shell.execute_reply.started": "2026-02-13T17:49:51.956086Z"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import xarray as xr\n",
+    "import datetime as dt\n",
+    "import earthaccess\n",
+    "import pydap\n",
+    "import requests\n",
+    "import matplotlib.pyplot as plt\n",
+    "# import pydap-specific tools\n",
+    "from pydap.net import create_session\n",
+    "from pydap.client import get_cmr_urls, consolidate_metadata, open_url\n",
+    "from pydap.client import to_netcdf as dap_to_netcdf"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "b807a4db-c4f6-40f6-9dab-43e398b2edb8",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-02-13T17:49:42.245933Z",
+     "iopub.status.busy": "2026-02-13T17:49:42.245490Z",
+     "iopub.status.idle": "2026-02-13T17:49:42.251180Z",
+     "shell.execute_reply": "2026-02-13T17:49:42.250447Z",
+     "shell.execute_reply.started": "2026-02-13T17:49:42.245918Z"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'3.5.9.dev41+g436dd71c5'"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pydap.__version__"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f358904c-f969-43c4-93ce-4d137c0492c8",
+   "metadata": {},
+   "source": [
+    "# Finding OPeNDAP URLs\n",
+    "\n",
+    "<span style='font-family:serif'> <font size=\"5.5\"><span style='color:#0066cc'> **Query opendap urls using NASA's CMR API**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "c7bdc702-f426-4b0a-a49f-2649ecdc7c18",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-02-13T17:49:55.877303Z",
+     "iopub.status.busy": "2026-02-13T17:49:55.877115Z",
+     "iopub.status.idle": "2026-02-13T17:49:56.514796Z",
+     "shell.execute_reply": "2026-02-13T17:49:56.514014Z",
+     "shell.execute_reply.started": "2026-02-13T17:49:55.877290Z"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "################################################ \n",
+      " We found a total of  117 OPeNDAP URLS!!!\n",
+      "################################################\n"
+     ]
+    }
+   ],
+   "source": [
+    "Callipso_L2_ccid = \"C3463063995-LARC_CLOUD\" # \n",
+    "time_range = [dt.datetime(2023, 5, 15), dt.datetime(2023, 5, 20)] # One month of data\n",
+    "\n",
+    "cmr_urls = get_cmr_urls(ccid=Callipso_L2_ccid, time_range=time_range, limit=1000) # you can incread the limit of results\n",
+    "\n",
+    "print(\"################################################ \\n We found a total of \", len(cmr_urls), \"OPeNDAP URLS!!!\\n################################################\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "4c4fd12d-ef2f-4739-b016-94e821cc89e2",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-02-13T17:49:57.988749Z",
+     "iopub.status.busy": "2026-02-13T17:49:57.988457Z",
+     "iopub.status.idle": "2026-02-13T17:49:57.992016Z",
+     "shell.execute_reply": "2026-02-13T17:49:57.991347Z",
+     "shell.execute_reply.started": "2026-02-13T17:49:57.988723Z"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# def get_opendap_urls(concept_id, time_range, _session=None):\n",
+    "#     \"\"\"\n",
+    "#     Queries NASA's `Common Metadata Repository` to identify all OPeNDAP URLS\n",
+    "#     given collection concept ID and temporal time range.\n",
+    "#     \"\"\"\n",
+    "#     cmr_url = 'https://cmr.earthdata.nasa.gov/search/granules'\n",
+    "#     if not _session:\n",
+    "#         _session = requests.Session() \n",
+    "#     cmr_response = _session.get(cmr_url, params={'concept_id': concept_id,'temporal': time_range,'page_size': 500}, headers={'Accept': 'application/json'})\n",
+    "#     granules = cmr_response.json()['feed']['entry']\n",
+    "#     granules_urls = []\n",
+    "    \n",
+    "#     # Filter and only retain the OPeNDAP URLs\n",
+    "#     for granule in granules:\n",
+    "#         item = next((item['href'] for item in granule['links'] if \"opendap\" in item[\"href\"]), None)\n",
+    "#         if item != None:\n",
+    "#             granules_urls.append(item)\n",
+    "#     return granules_urls\n",
+    "\n",
+    "# start_date =  dt.datetime(2023, 5, 15)\n",
+    "# end_date =dt.datetime(2023, 5, 20)\n",
+    "\n",
+    "# print(start_date, end_date,sep='\\n')\n",
+    "\n",
+    "# dt_format = '%Y-%m-%dT%H:%M:%SZ' # format requirement for datetime search\n",
+    "# temporal_str = start_date.strftime(dt_format) + ',' + end_date.strftime(dt_format)\n",
+    "\n",
+    "# cmr_urls = get_opendap_urls(Callipso_L2_ccid, temporal_str)\n",
+    "# print(len(cmr_urls))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f9ea1330-8390-4ae2-b580-45f039bf9aa6",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "cmr_urls[0]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8d9882ef-e8cd-49f8-b627-026047124459",
+   "metadata": {},
+   "source": [
+    "# Inspecting Metadata\n",
+    "\n",
+    "<span style='font-family:serif'> <font size=\"5.5\"><span style='color:#0066cc'> **Understanding DAP4**\n",
+    "\n",
+    "<div style=\"text-align:center\">\n",
+    "<img src=\"figures/DAP4vsDAP2.png\" alt=\"drawing\" width=\"750\"/>    \n",
+    "</div>\n",
+    "\n",
+    "\n",
+    "### Basic Data Exploration\n",
+    "\n",
+    "<font size=\"3.5\">To inspect the metadata of a remote OPeNDAP URL (variables in the file), you :\n",
+    "\n",
+    "* <font size=\"3.5\"> Append a `.dmr` at the end of the URL\n",
+    "* <font size=\"3.5\"> Open on a browser.\n",
+    "* <font size=\"3.5\"> Useful when interested in subseting by variables for example.\n",
+    "\n",
+    "For example:\n",
+    "    \n",
+    "https://opendap.earthdata.nasa.gov/collections/C3463063995-LARC_CLOUD/granules/CAL_LID_L2_01kmCLay-Standard-V5-00.2023-05-15T23-26-01ZD.hdf\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6e04deee-6c59-4437-9aed-381a73085496",
+   "metadata": {},
+   "source": [
+    "<span style='font-family:serif'> <font size=\"5.5\"><span style='color:#0066cc'> **EDL Authentication via OPeNDAP**\n",
+    "\n",
+    "<font size=\"3.5\"> You can authenticate via:\n",
+    "\n",
+    "* <font size=\"3.5\"> `.netrc` file (username password)\n",
+    "* <font size=\"3.5\"> Token bearer header\n",
+    "\n",
+    "\n",
+    "<font size=\"3.5\"> OPeNDAP's Hyrax server support both forms of authentication. Below we demonstrate using earthaccess to store and inherit EDL credentials into a session that will be used to stream data from OPeNDAP in the Cloud.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "2725988f-618e-4ed4-879c-3adc0c4771e4",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-02-13T17:50:08.858796Z",
+     "iopub.status.busy": "2026-02-13T17:50:08.858560Z",
+     "iopub.status.idle": "2026-02-13T17:50:16.927525Z",
+     "shell.execute_reply": "2026-02-13T17:50:16.926590Z",
+     "shell.execute_reply.started": "2026-02-13T17:50:08.858780Z"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "auth = earthaccess.login(strategy=\"netrc\", persist=True) # you will be promted to add your EDL credentials\n",
+    "\n",
+    "# pass Token Authorization to a new Session.\n",
+    "my_session = create_session(session=auth.get_session())\n",
+    "# my_session = requests.session()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a2322093-b9b6-49c5-8bb4-7ad17bffb95d",
+   "metadata": {},
+   "source": [
+    "# Accessing Metadata\n",
+    "\n",
+    "<font size=\"3.5\"> What are some tools, their differences, and what do they do.\n",
+    "\n",
+    "<span style='font-family:serif'> <font size=\"5.5\"><span style='color:#0066cc'> **PYDAP: Metadata-Only**\n",
+    "\n",
+    "\n",
+    "\n",
+    "```{note}\n",
+    "Q: How do we tell the server which protocol to use?\n",
+    "A: By replaing the http -> dap4 in the URL\n",
+    "```\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e2c24537-2148-456a-98a2-a594c45484a4",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "pyds = open_url(cmr_urls[0], protocol=\"dap4\", session=my_session)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "da46dc24-4989-4e0d-9ddb-bb4b93feaef1",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "pyds.tree()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "9274139d-3312-4a38-9707-4053f0247233",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-02-13T17:50:35.877985Z",
+     "iopub.status.busy": "2026-02-13T17:50:35.877636Z",
+     "iopub.status.idle": "2026-02-13T17:54:24.106343Z",
+     "shell.execute_reply": "2026-02-13T17:54:24.105497Z",
+     "shell.execute_reply.started": "2026-02-13T17:50:35.877957Z"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "nbytes = []\n",
+    "for url in cmr_urls:\n",
+    "    pyds = open_url(url, protocol=\"dap4\", session=my_session)\n",
+    "    nbytes.append(pyds.nbytes)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "48a20365-c795-41cd-a122-2386da3e4b0b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-03-10T23:46:18.780036Z",
+     "iopub.status.busy": "2026-03-10T23:46:18.779775Z",
+     "iopub.status.idle": "2026-03-10T23:46:18.911787Z",
+     "shell.execute_reply": "2026-03-10T23:46:18.911008Z",
+     "shell.execute_reply.started": "2026-03-10T23:46:18.780014Z"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "ename": "NameError",
+     "evalue": "name 'nbytes' is not defined",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
+      "\u001b[31mNameError\u001b[39m                                 Traceback (most recent call last)",
+      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[1]\u001b[39m\u001b[32m, line 1\u001b[39m\n\u001b[32m----> \u001b[39m\u001b[32m1\u001b[39m \u001b[38;5;28msum\u001b[39m(\u001b[43mnbytes\u001b[49m)\n",
+      "\u001b[31mNameError\u001b[39m: name 'nbytes' is not defined"
+     ]
+    }
+   ],
+   "source": [
+    "sum(nbytes)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6d3b2e98-5050-4e46-85e0-f977efc69174",
+   "metadata": {},
+   "source": [
+    "<span style='font-family:serif'> <font size=\"5\"><span style='color:#0066cc'> **Recommended Worklow for Streaming Data**\n",
+    "\n",
+    "\n",
+    "* <font size=\"3.5\"><span style='color:#0066cc'> **Data Exploration**</span>: `Xarray + PyDAP`. When interested in visualizing one or two variables. Identify regions of interest (interactively).\n",
+    "\n",
+    "However, if the goal is to stream data via OPeNDAP, Xarray+opendap requires extra logic to get the **best performance** that is stil subpar compared to **talking to the server directly**\n",
+    "\n",
+    "\n",
+    "* <font size=\"3.5\"><span style='color:#0066cc'> **Streaming a Data Subset**</span>: Pure PyDAP to parallelize direct server (subset) requests. See below:\n",
+    "\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6879445c-cae7-4b7b-a729-f5f7e4e8c805",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "5b87a6c6-6bb3-4c3b-b1a1-2f61c8ff5eea",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-02-13T18:00:04.171747Z",
+     "iopub.status.busy": "2026-02-13T18:00:04.171534Z",
+     "iopub.status.idle": "2026-02-13T18:00:04.175169Z",
+     "shell.execute_reply": "2026-02-13T18:00:04.174489Z",
+     "shell.execute_reply.started": "2026-02-13T18:00:04.171732Z"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "?dap4.ce=/Lidar_Surface_Detection;/Ocean_Derived_Column_Optical_Depth;/Lidar_Data_Altitudes;/Profile_ID;/Latitude;/Longitude;/Profile_Time;/Profile_UTC_Time;/Day_Night_Flag;/Tropopause_Height;/Tropopause_Temperature;/Snow_Ice_Surface_Type;/Opacity_Flag\n"
+     ]
+    }
+   ],
+   "source": [
+    "output_path = \"/home/idies/workspace/Temporary/Mikejmnez/scratch/data/\"\n",
+    "\n",
+    "# keep_variables = [\"Lidar_Data_Altitudes\", \"Profile_ID\", \"Latitude\", \"Longitude\",\n",
+    "#                   \"Profile_Time\", \"Profile_UTC_Time\", \"Tropopause_Height\", \"Tropopause_Temperature\", \n",
+    "#                   \"Ocean_Derived_Column_Optical_Depth\", \"Lidar_Surface_Detection\"]\n",
+    "keep_variables = [\n",
+    "    '/Lidar_Surface_Detection', \"/Ocean_Derived_Column_Optical_Depth\",\n",
+    "    \"/Lidar_Data_Altitudes\", \"/Profile_ID\", \"/Latitude\", \"/Longitude\", \n",
+    "    \"/Profile_Time\", \"/Profile_UTC_Time\", \"/Day_Night_Flag\", \"/Tropopause_Height\", \n",
+    "    \"/Tropopause_Temperature\",\"/Snow_Ice_Surface_Type\", \"/Opacity_Flag\", \n",
+    "]\n",
+    "dap4ce = \"?dap4.ce=\"+\";\".join(keep_variables)\n",
+    "print(dap4ce)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9157e777-de43-448f-a7f4-a17c4907261e",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "cmr_urls[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2b654da8-3b02-4448-b0a5-bba810b0a84d",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "cmr_urls[1]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "71e11f81-b17f-416a-8342-7da78035ae81",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "# Single File\n",
+    "\n",
+    "### OPeNDAP + pydap-only logic\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f856e281-d1c5-4004-a0bf-45415eb827a3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-02-09T22:55:41.551764Z",
+     "iopub.status.busy": "2026-02-09T22:55:41.551538Z",
+     "iopub.status.idle": "2026-02-09T22:55:41.554773Z",
+     "shell.execute_reply": "2026-02-09T22:55:41.553942Z",
+     "shell.execute_reply.started": "2026-02-09T22:55:41.551749Z"
+    }
+   },
+   "source": [
+    "### metadata only"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6901027f-8483-4bb7-9ff3-2c067ed7a228",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "pyds = open_url(cmr_urls[0].replace(\"https\", \"dap4\")+dap4ce, session=my_session)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "baac9930-71a8-4f56-acd4-5c0134e3ea7f",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "pyds.tree()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "11c50815-bd69-4b51-9116-3498fb3cc591",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b840dab4-ec1f-4272-963e-13dbeeffcd4f",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "to_netcdf(cmr_urls[0], session=my_session, keep_variables=keep_variables, output_path=output_path)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "40d812ff-c268-4a86-b18b-8e1f939f2100",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# dT = xr.open_datatree(output_path+\"/CAL_LID_L2_01kmCLay-Standard-V5-00.2023-05-15T23-26-01ZD.nc4\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1ef7f417-0f3a-434b-9a57-72537debaef8",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# dT"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "57767946-f91c-4d8d-966a-7f87dc19a1d8",
+   "metadata": {},
+   "source": [
+    "### xarray approach\n",
+    "\n",
+    "- 2-step process: \n",
+    "1. Create an Xarray Dataset object.\n",
+    "2. Download as file of choice.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e88a0682-0835-430a-8922-3e43b7cd2847",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "ds = xr.open_datatree(cmr_urls[0].replace(\"https\", \"dap4\")+dap4ce, session=my_session, engine='pydap')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "50c5356d-4430-4193-9675-4b8f4f743ce5",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "ds.to_netcdf(output_path+'/single_download.nc4')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "278c9cbc-5f5c-4351-a5f4-cd9630493199",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### Multiple downloads\n",
+    "\n",
+    "- OPenDAP & pydap-only approach"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "1c9d5e9e-0228-406c-81db-6318169e138f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-02-13T18:00:37.956127Z",
+     "iopub.status.busy": "2026-02-13T18:00:37.955791Z",
+     "iopub.status.idle": "2026-02-13T18:02:21.409005Z",
+     "shell.execute_reply": "2026-02-13T18:02:21.408229Z",
+     "shell.execute_reply.started": "2026-02-13T18:00:37.956100Z"
+    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "bc233a9ddf264d5c99a1a25b414ed527",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Downloading (117 remote files):   0%|          | 0/117 [00:00<?, ?url/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 161 ms, sys: 30.5 ms, total: 191 ms\n",
+      "Wall time: 1min 43s\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "dap_to_netcdf(cmr_urls, session=my_session, keep_variables=keep_variables, output_path=output_path)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a2724c6e-e182-48c2-8ec2-400f2e3d1f11",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0da35e08-efd4-4186-9337-b370e27c3712",
+   "metadata": {},
+   "source": [
+    "## check the data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2ce9e542-d57e-4229-9454-129d57c51a82",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "93fa4be6-28a7-441f-8f79-f1f2c1666e90",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-02-13T18:04:23.461353Z",
+     "iopub.status.busy": "2026-02-13T18:04:23.461041Z",
+     "iopub.status.idle": "2026-02-13T18:04:23.502549Z",
+     "shell.execute_reply": "2026-02-13T18:04:23.501720Z",
+     "shell.execute_reply.started": "2026-02-13T18:04:23.461336Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "ds = xr.open_datatree(output_path+\"CAL_LID_L2_01kmCLay-Standard-V5-00.2023-05-17T15-41-01ZN.nc4\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "0e244f79-a6b1-4a72-b77a-d9b3b831f607",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-02-13T18:07:08.188794Z",
+     "iopub.status.busy": "2026-02-13T18:07:08.188440Z",
+     "iopub.status.idle": "2026-02-13T18:07:08.194838Z",
+     "shell.execute_reply": "2026-02-13T18:07:08.194063Z",
+     "shell.execute_reply.started": "2026-02-13T18:07:08.188768Z"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "\n",
+    "data_dir = Path(output_path)  # <-- change this\n",
+    "files = sorted(data_dir.glob(\"*.nc4\"))  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "20d6d9a8-18bc-4681-ac22-44908b6b2b1c",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "177c4ea4-7284-4b2d-84f2-6308bd464660",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3.13",
+   "language": "python",
+   "name": "earthdata2026"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/binder/DAYMET.ipynb
+++ b/binder/DAYMET.ipynb
@@ -26,7 +26,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "5291bdb6-13c8-4c18-b66e-e4fddb9f3464",
    "metadata": {},
    "outputs": [],
@@ -59,7 +59,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "51b125f6-87ac-4bb2-9233-ac912da78d21",
    "metadata": {},
    "outputs": [],
@@ -88,28 +88,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "6ff131fc-1d33-4168-a107-f169ef2b1391",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "################################################ \n",
-      " We found a total of  165 OPeNDAP URLS!!!\n",
-      "################################################\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/miguelangeljimenezurias/mambaforge/envs/Earthdata2026/lib/python3.12/site-packages/pydap/client.py:1227: UserWarning: Failed to find opendap urls with C2531982907-ORNL_CLOUD. Try again, and make sure the parameters are correct. If you think this is an issue with pydap or the cmr, consider opening an issue on the pydap github repository\n",
-      "  warnings.warn(\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "daymet_ccid = \"C2531982907-ORNL_CLOUD\" # \n",
     "time_range = [dt.datetime(2014, 5, 15), dt.datetime(2024, 5, 15)] # One month of data\n",

--- a/binder/DAYMET_example.ipynb
+++ b/binder/DAYMET_example.ipynb
@@ -26,7 +26,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "5291bdb6-13c8-4c18-b66e-e4fddb9f3464",
    "metadata": {},
    "outputs": [],
@@ -51,21 +51,20 @@
     "<font size=\"3.5\"> You can authenticate via earthaccess as demonstrated below. You must have a valid EDL account. There are two strategies for authenticating with `earthaccess`:\n",
     "\n",
     "1. `strategy=\"interactive\"`. This will promt your edl username-password.\n",
-    "2. `strategy=\"netrc\"`. Use this if the notebook is running on an environment where a `.netrc` with your credentials is recoverable.\n",
+    "2. `strategy=\"netrc\"`. Use this if the notebook is running on an environment where a `.netrc` with your credentials is recoverable. T\n",
     "\n",
-    "<font size=\"3.5\">Below the default will be `interactive`.\n",
-    "\n",
-    "<font size=\"3.5\"> Having authenticated, pydap can inherit a requests.Session object from earthaccess, containing all valid credentials. When sending data requests to the NASA OPeNDAP server, the server will inherit these credentials, and verify authentication when needed to send data back."
+    "<font size=\"3.5\"> Below the default will be `netrc`, assuming the user has executed the notebook **Authenticate.ipynb**. If not, you can change the strategy to `\"interactive\"`.\n",
+    "\n"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "51b125f6-87ac-4bb2-9233-ac912da78d21",
    "metadata": {},
    "outputs": [],
    "source": [
-    "auth = earthaccess.login(strategy=\"netrc\", persist=True) # you will be promted to add your EDL credentials\n",
+    "auth = earthaccess.login(strategy=\"netrc\", persist=True) # \n",
     "\n",
     "# pass Token Authorization to a new Session.\n",
     "my_session = auth.get_session()"
@@ -89,10 +88,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "6ff131fc-1d33-4168-a107-f169ef2b1391",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "################################################ \n",
+      " We found a total of  165 OPeNDAP URLS!!!\n",
+      "################################################\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/miguelangeljimenezurias/mambaforge/envs/Earthdata2026/lib/python3.12/site-packages/pydap/client.py:1227: UserWarning: Failed to find opendap urls with C2531982907-ORNL_CLOUD. Try again, and make sure the parameters are correct. If you think this is an issue with pydap or the cmr, consider opening an issue on the pydap github repository\n",
+      "  warnings.warn(\n"
+     ]
+    }
+   ],
    "source": [
     "daymet_ccid = \"C2531982907-ORNL_CLOUD\" # \n",
     "time_range = [dt.datetime(2014, 5, 15), dt.datetime(2024, 5, 15)] # One month of data\n",

--- a/binder/DAYMET_example.ipynb
+++ b/binder/DAYMET_example.ipynb
@@ -165,16 +165,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "448634d3-ff5f-4467-9064-dbcd823dd055",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "ds = xr.open_dataset(prcp_na_urls[0].replace(\"https\", \"dap4\"), session=my_session, engine='pydap')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
    "id": "e2f8fbac-c0fb-4e99-9518-52c1acc213f7",
    "metadata": {},
    "outputs": [],
@@ -395,7 +385,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.12"
+   "version": "3.12.13"
   }
  },
  "nbformat": 4,

--- a/binder/Ecostress.ipynb
+++ b/binder/Ecostress.ipynb
@@ -1,0 +1,209 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "36b5ffd4-3792-463a-adcc-5ac4ec7cb52b",
+   "metadata": {},
+   "source": [
+    "# Accessing ECOSTRESS data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3f0edcaa-eab7-4e3c-9cd7-147f1c533b92",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import xarray as xr\n",
+    "import datetime as dt\n",
+    "import earthaccess\n",
+    "import pydap\n",
+    "import matplotlib.pyplot as plt\n",
+    "# import pydap-specific tools\n",
+    "from pydap.client import get_cmr_urls, open_url\n",
+    "import numpy as np\n",
+    "from pydap.client import to_netcdf as dap_to_netcdf"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e5314a52-96fb-40d7-96a6-e9dfbbed1bce",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dc3254a5-bd89-4920-b63e-5bf4bb7d9638",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "auth = earthaccess.login(strategy=\"netrc\", persist=True) # you will be promted to add your EDL credentials\n",
+    "\n",
+    "# pass Token Authorization to a new Session.\n",
+    "my_session = session=auth.get_session()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "73ac448e-52e0-4656-b189-34cb26767821",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d67419f8-bbc1-4274-90ee-cc4efe3fec6c",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "ECOSTRESS_ccid = \"C2076114664-LPCLOUD\"\n",
+    "bounding_box = [-128.847656,41.112469,-107.050781,46.679594]\n",
+    "time_range = [dt.datetime(2025, 3, 1), dt.datetime(2025, 3, 14)]\n",
+    "\n",
+    "\n",
+    "cmr_urls = get_cmr_urls(ccid=ECOSTRESS_ccid, bounding_box = bounding_box, limit=1000, time_range=time_range) # limit by default = 50\n",
+    "\n",
+    "print(\"################################################ \\n We found a total of \", len(cmr_urls), \"OPeNDAP URLS!!!\\n################################################\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "77674df4-3b1f-4522-ad43-54d80e0183cc",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "pyds = open_url(cmr_urls[0], protocol=\"dap4\", session=my_session)\n",
+    "pyds.tree()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7744670c-cc38-4f92-a6bc-65e640657e8f",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "keep_vars = ['/SDS/LST',\n",
+    "             \"/StandardMetadata/EastBoundingCoordinate\", \n",
+    "             \"/StandardMetadata/SouthBoundingCoordinate\", \n",
+    "             \"/StandardMetadata/NorthBoundingCoordinate\",\n",
+    "             \"/StandardMetadata/DayNightFlag\",\n",
+    "             \"/StandardMetadata/WestBoundingCoordinate\",\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "515e03de-30c2-45a9-bc34-0f491bdaed91",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "# Stream data into local directory\n",
+    "\n",
+    "Stream each remote file into an individual file, since these cannot be aggregated.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f6936bb4-ed79-49e2-b70f-1f1256a60b78",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "output_path = \"data/\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5fb47fd7-0743-4723-979b-e97ce2068303",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "dap_to_netcdf(cmr_urls, session=my_session, output_path = output_path, keep_variables=keep_vars)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a2765385-8703-4536-93ad-b3d9b6daba57",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0f7d60fb-6bad-4a97-a51c-2a9682396ec8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dt = xr.open_datatree(\"data/ECOv002_L2_LSTE_37723_006_20250302T070023_0713_01.nc4\")\n",
+    "dt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "30c713c6-cee4-4ba4-8b4c-1edb8ee09583",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "dt['SDS/LST'].isel(dim0=slice(0, 1000), dim1=slice(0, 1400)).plot()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7b095687-800d-48c2-a1cc-50cd8f733fb0",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/binder/Ecostress.ipynb
+++ b/binder/Ecostress.ipynb
@@ -100,8 +100,8 @@
    "outputs": [],
    "source": [
     "keep_vars = ['/SDS/LST',\n",
-    "             \"/StandardMetadata/EastBoundingCoordinate\", \n",
-    "             \"/StandardMetadata/SouthBoundingCoordinate\", \n",
+    "             \"/StandardMetadata/EastBoundingCoordinate\",\n",
+    "             \"/StandardMetadata/SouthBoundingCoordinate\",\n",
     "             \"/StandardMetadata/NorthBoundingCoordinate\",\n",
     "             \"/StandardMetadata/DayNightFlag\",\n",
     "             \"/StandardMetadata/WestBoundingCoordinate\",\n",

--- a/binder/MERRA2.ipynb
+++ b/binder/MERRA2.ipynb
@@ -1,0 +1,379 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "22ce9e8c-70bc-44f8-a736-461d2e2f5f78",
+   "metadata": {},
+   "source": [
+    "# MERRA-2\n",
+    "\n",
+    "\n",
+    "Access to MERRA-2 data, streaming N granules to N local files. Subsetting takes place close to data. With data close to Client API, any subsequent aggregation, when possible, takes place close to the client. Reducing the amount of (remote) requests behind EDL authentication that Xarray makes. Furthermore, because subsetting takes place close to the data, then:\n",
+    "\n",
+    "* Bytes are streamed as soon as they are processed by the server.\n",
+    "* Amount of data stream is much less than the entire file.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "678a1374-c0e3-4620-8bbe-337750f67895",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import xarray as xr\n",
+    "import datetime as dt\n",
+    "import earthaccess\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "# import pydap-specific tools\n",
+    "from pydap.client import open_url, get_cmr_urls \n",
+    "from pydap.client import to_netcdf as dap_to_netcdf"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9c087d99-a226-4856-a98b-39c2b6505674",
+   "metadata": {},
+   "source": [
+    "# Finding OPeNDAP URLs\n",
+    "\n",
+    "<span style='font-family:serif'> <font size=\"5.5\"><span style='color:#0066cc'> **Query opendap urls using NASA's CMR API**    \n",
+    "    \n",
+    "We are interested in `MERRA-2` data, hourly data. MERRA-2 has several collections, organized by data products and frequency of data. In this case, we are interested in hourly data from the following collections:\n",
+    "    \n",
+    "* **doi**: 10.5067/QBZ6MG944HW0, **shortname**: M2I3NPASM. **Variables of interest**: air_temperature, surface_pressure, Ertel's Potential Vorticity, northward_wind, eastward_wind, specific_humidity, ozone_mass_mixing_ratio and (dimensions). Further information [click here]( https://disc.gsfc.nasa.gov/datasets/M2I3NPASM_5.12.4/summary).\n",
+    "\n",
+    "* **doi**: 10.5067/HO9OVZWF3KW2, **shortname**: M2I3NVCHM, **Variables of interest**: Carbon Monoxide, O3 (and dimensions data). Further information [click here](https://disc.gsfc.nasa.gov/datasets/M2I3NVCHM_5.12.4/summary).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f3892871-06c7-4359-8429-c95b0a037387",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "MERRA2_M2I3NPASM_doi = \"10.5067/QBZ6MG944HW0\" # \n",
+    "MERRA2_M2I3NPASM_ccid = \"C1276812879-GES_DISC\"\n",
+    "\n",
+    "MERRA2_M2I3NVCHM_doi = \"10.5067/HO9OVZWF3KW2\"\n",
+    "MERRA2_M2I3NVCHM_ccid = \"C1276812901-GES_DISC\"\n",
+    "\n",
+    "year_start = 2024\n",
+    "year_end = 2025\n",
+    "\n",
+    "\n",
+    "time_ranges = [[dt.datetime(year, 9, 21), dt.datetime(year, 11, 22)] for year in range(year_start, year_end)]\n",
+    "\n",
+    "cmr_urls1 = [urls for time in time_ranges for urls in get_cmr_urls(doi=MERRA2_M2I3NPASM_doi, time_range=time, limit=1000)] # you can incread the limit of results\n",
+    "cmr_urls2 = [urls for time in time_ranges for urls in get_cmr_urls(doi=MERRA2_M2I3NVCHM_doi, time_range=time, limit=1000)]\n",
+    "\n",
+    "print(\"################################################ \\n We found a total of \", len(cmr_urls1)+len(cmr_urls2), \"OPeNDAP URLS!!!\\n################################################\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8c337e30-9e56-46cd-92ec-5a2c6f51b282",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "len(cmr_urls1), len(cmr_urls2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "17407c14-2ef3-44c4-b4be-0caf2c1254bc",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "auth = earthaccess.login(strategy=\"netrc\", persist=True) # you will be promted to add your EDL credentials\n",
+    "\n",
+    "# pass Token Authorization to a new Session.\n",
+    "my_session = auth.get_session()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "940f4a86-376b-4e33-b396-e1885be6f384",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "pyds1 = open_url(cmr_urls1[0], protocol=\"dap4\", session=my_session)\n",
+    "pyds1.tree()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c48f3491-700f-4984-92dd-2a813f656057",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "pyds2 = open_url(cmr_urls2[0], protocol=\"dap4\", session=my_session)\n",
+    "pyds2.tree()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "91bb8dda-25c3-4843-a0a1-6375504ecf73",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fd25c099-b3c3-41df-a9d0-a8d87b92ed6f",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# output data directory\n",
+    "\n",
+    "output_path = \"data/\"\n",
+    "\n",
+    "Variables1 = [\"/U\", \"/V\", \"/T\",\"/PS\"]\n",
+    "dims1 = list(set([dim for var in pyds1 for dim in pyds1[var].dims]))\n",
+    "Variables1 += dims1\n",
+    "print(\"Download only Vars in 1: \", Variables1)\n",
+    "\n",
+    "Variables2 = [\"/CO\", \"/O3\"]\n",
+    "dims2 = list(set([dim for var in pyds2 for dim in pyds2[var].dims]))\n",
+    "Variables2 += dims2\n",
+    "print(\"Download only Vars in 2: \", Variables2)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8c5d1261-1709-463d-a959-793903600aa9",
+   "metadata": {},
+   "source": [
+    "## Subset by lat/lon regions\n",
+    "\n",
+    "\n",
+    "In addition to subsetting by Variable names, We are interested in a region of the NorthAtlantic Ocean delimited by:\n",
+    "\n",
+    "\n",
+    "Currently the dap4 server does not support subset by coordinate value. Instead, we need to download the dimension data (lat and lon) to find out the slices needed to download only the spatial subset of interest. Xarray+pydap, by default, downloads all dimension data in a single request. WE can use the Xarray dataset to construct the dim slice of interest.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "24169312-66d1-4d76-b3b4-cc762d104ad0",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "lat_min, lat_max = 15, 65\n",
+    "lon_min, lon_max = -75, 15"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7958e7af-f7fd-47dd-bb98-ab577de8f163",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## Load coordinate data \n",
+    "\n",
+    "We only need one single file per collection."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d3ab8955-2696-4d0c-8f79-07c580a10d08",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "ds1 = xr.open_dataset(cmr_urls1[0].replace(\"https\", \"dap4\"), engine=\"pydap\", session=my_session)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0e707215-16a5-43a3-b776-dcea1753bddb",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "ds2 = xr.open_dataset(cmr_urls2[0].replace(\"https\", \"dap4\"), engine=\"pydap\", session=my_session)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3145a5c0-882f-46cb-a690-ff5c6faf4277",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c5001515-4363-4bb5-a1e2-78f285634cc4",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-03-11T19:07:47.849897Z",
+     "iopub.status.busy": "2026-03-11T19:07:47.849749Z",
+     "iopub.status.idle": "2026-03-11T19:07:47.866310Z",
+     "shell.execute_reply": "2026-03-11T19:07:47.865370Z",
+     "shell.execute_reply.started": "2026-03-11T19:07:47.849880Z"
+    },
+    "tags": []
+   },
+   "source": [
+    "### check that coordinate data is equalacross collections\n",
+    "\n",
+    "This is a necessary step, to check if same subset can be applied to data from both collections\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2b6f290d-da8b-4e6d-9839-9930e01b1de5",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "Lon1, Lat1 = ds1['lon'], ds1['lat']\n",
+    "Lon2, Lat2 = ds2['lon'], ds2['lat']\n",
+    "\n",
+    "\n",
+    "iLon1 = np.where((Lon1>lon_min)&(Lon1 < lon_max))[0]\n",
+    "iLon2 = np.where((Lon2>lon_min)&(Lon2 < lon_max))[0]\n",
+    "\n",
+    "iLat1 = np.where((Lat1>lat_min)&(Lat1 < lat_max))[0]\n",
+    "iLat2 = np.where((Lat2>lat_min)&(Lat2 < lat_max))[0]\n",
+    "\n",
+    "if all(iLon1==iLon2) and all(iLat1==iLat2):\n",
+    "    iLon = iLon1\n",
+    "    iLat = iLat2\n",
+    "    print(\"Both collections belong to same Level 3 model output\")\n",
+    "else:\n",
+    "    print('Data is not Level 3')\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d482fc26-4105-4704-a63b-7eb9c45886c7",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "dim_slices = {\n",
+    "    'lon': (iLon[0], iLon[-1]), \n",
+    "    'lat': (iLat[0], iLat[-1]),\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ae664d62-3b9a-45c7-bb55-04ad7c1a15b7",
+   "metadata": {},
+   "source": [
+    "# Stream data into local directory"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "74ed7ff6-a6fe-4907-98a7-8d0d8ca82d58",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "dap_to_netcdf(cmr_urls1, session=my_session, keep_variables=Variables1, dim_slices=dim_slices, output_path=output_path)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1c9a157e-7dfd-46b5-aeca-86c52a492f22",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "dap_to_netcdf(cmr_urls2, session=my_session, keep_variables=Variables2, dim_slices=dim_slices, output_path=output_path)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7cc9bef6-08a1-4ea3-9431-a79befc436d3",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "ds = xr.open_mfdataset(output_path+\"/*.nc4\")\n",
+    "ds"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6747440b-4135-4950-8b76-2c0cc90e3b46",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/binder/MERRA2.ipynb
+++ b/binder/MERRA2.ipynb
@@ -151,7 +151,6 @@
    "outputs": [],
    "source": [
     "# output data directory\n",
-    "\n",
     "output_path = \"data/\"\n",
     "\n",
     "Variables1 = [\"/U\", \"/V\", \"/T\",\"/PS\"]\n",
@@ -342,7 +341,7 @@
    },
    "outputs": [],
    "source": [
-    "ds = xr.open_mfdataset(output_path+\"/*.nc4\")\n",
+    "ds = xr.open_mfdataset(output_path+\"/MERRA2_*.nc4\")\n",
     "ds"
    ]
   },

--- a/binder/MERRA2.ipynb
+++ b/binder/MERRA2.ipynb
@@ -8,7 +8,7 @@
     "# MERRA-2\n",
     "\n",
     "\n",
-    "Access to MERRA-2 data, streaming N granules to N local files. Subsetting takes place close to data. With data close to Client API, any subsequent aggregation, when possible, takes place close to the client. Reducing the amount of (remote) requests behind EDL authentication that Xarray makes. Furthermore, because subsetting takes place close to the data, then:\n",
+    "<span style='font-family:serif'><font size=\"3.5\"> Access to MERRA-2 data, streaming N granules to N local files. Subsetting takes place close to data. With data close to Client API, any subsequent aggregation, when possible, takes place close to the client. Reducing the amount of (remote) requests behind EDL authentication that Xarray makes. Furthermore, because subsetting takes place close to the data, then:\n",
     "\n",
     "* Bytes are streamed as soon as they are processed by the server.\n",
     "* Amount of data stream is much less than the entire file.\n"
@@ -68,7 +68,7 @@
     "year_end = 2025\n",
     "\n",
     "\n",
-    "time_ranges = [[dt.datetime(year, 9, 21), dt.datetime(year, 11, 22)] for year in range(year_start, year_end)]\n",
+    "time_ranges = [[dt.datetime(year, 9, 21), dt.datetime(year, 10, 22)] for year in range(year_start, year_end)]\n",
     "\n",
     "cmr_urls1 = [urls for time in time_ranges for urls in get_cmr_urls(doi=MERRA2_M2I3NPASM_doi, time_range=time, limit=1000)] # you can incread the limit of results\n",
     "cmr_urls2 = [urls for time in time_ranges for urls in get_cmr_urls(doi=MERRA2_M2I3NVCHM_doi, time_range=time, limit=1000)]\n",
@@ -172,10 +172,7 @@
     "## Subset by lat/lon regions\n",
     "\n",
     "\n",
-    "In addition to subsetting by Variable names, We are interested in a region of the NorthAtlantic Ocean delimited by:\n",
-    "\n",
-    "\n",
-    "Currently the dap4 server does not support subset by coordinate value. Instead, we need to download the dimension data (lat and lon) to find out the slices needed to download only the spatial subset of interest. Xarray+pydap, by default, downloads all dimension data in a single request. WE can use the Xarray dataset to construct the dim slice of interest.\n"
+    "<span style='font-family:serif'><font size=\"3.5\"> In addition to subsetting by Variable names, We are interested in a region of the NorthAtlantic Ocean delimited by:\n"
    ]
   },
   {
@@ -230,16 +227,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "3145a5c0-882f-46cb-a690-ff5c6faf4277",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
    "cell_type": "markdown",
    "id": "c5001515-4363-4bb5-a1e2-78f285634cc4",
    "metadata": {
@@ -255,7 +242,7 @@
    "source": [
     "### check that coordinate data is equalacross collections\n",
     "\n",
-    "This is a necessary step, to check if same subset can be applied to data from both collections\n"
+    "<span style='font-family:serif'><font size=\"3.5\"> This is a necessary step, to check if same subset can be applied to data from both collections\n"
    ]
   },
   {
@@ -333,6 +320,14 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "db5cec03-3209-4dfc-a94a-6f7b7bf388b6",
+   "metadata": {},
+   "source": [
+    "## Inspect the data"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "7cc9bef6-08a1-4ea3-9431-a79befc436d3",
@@ -341,14 +336,33 @@
    },
    "outputs": [],
    "source": [
-    "ds = xr.open_mfdataset(output_path+\"/MERRA2_*.nc4\")\n",
-    "ds"
+    "ds1 = xr.open_mfdataset(output_path+\"/MERRA2_400.inst3_3d_asm_*.nc4\")\n",
+    "ds1"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "6747440b-4135-4950-8b76-2c0cc90e3b46",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds2 = xr.open_mfdataset(output_path+\"/MERRA2_400.inst3_3d_chm_*.nc4\")\n",
+    "ds2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "68d08ba2-8fd2-492a-b263-3b3c02b3cd44",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0c314b05-5fb0-47ce-a856-dee208f82985",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/binder/PACEL3_Chrol_a.ipynb
+++ b/binder/PACEL3_Chrol_a.ipynb
@@ -7,7 +7,7 @@
     "tags": []
    },
    "source": [
-    "# Accssing PACE data"
+    "# Access PACE data with OPeNDAP"
    ]
   },
   {
@@ -60,7 +60,7 @@
    "outputs": [],
    "source": [
     "PACE_ccid = \"C3620140256-OB_CLOUD\" # version 3.1 \n",
-    "time_range=[dt.datetime(2025, 1, 1), dt.datetime(2025, 6, 30)]\n",
+    "time_range=[dt.datetime(2025, 1, 1), dt.datetime(2025, 3, 30)]\n",
     "cmr_urls = get_cmr_urls(ccid=PACE_ccid, limit=1000, time_range=time_range) # limit by default = 50\n",
     "\n",
     "print(\"################################################ \\n We found a total of \", len(cmr_urls), \"OPeNDAP URLS!!!\\n################################################\")"
@@ -199,7 +199,7 @@
    "outputs": [],
    "source": [
     "%%time\n",
-    "dap_to_netcdf(chlor_a_urls[:10], session=my_session, keep_variables=keep_variables, dim_slices=dim_slices, output_path=output_path)"
+    "dap_to_netcdf(chlor_a_urls, session=my_session, keep_variables=keep_variables, dim_slices=dim_slices, output_path=output_path)"
    ]
   },
   {
@@ -208,17 +208,6 @@
    "metadata": {},
    "source": [
     "## Inspect local files"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "a2c2e44f-6671-4dc7-8146-5fe51f33a345",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "ds = xr.open_dataset(output_path+'PACE_OCI.20250101.L3m.DAY.CHL.V3_1.chlor_a.4km.nc4')\n",
-    "ds"
    ]
   },
   {
@@ -237,7 +226,36 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fbc004a3-2686-4f9e-8466-1efb287d4741",
+   "id": "6681e00c-8d7f-4263-b988-9b35a823c2dc",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f4adeda3-0818-48ae-8083-3a9183469533",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "vmin = ds['chlor_a'].attrs['display_min']\n",
+    "vmax = ds['chlor_a'].attrs['display_max']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2285766b-0d25-4c93-b082-cb1306bfbff0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "chlor_a.plot.contourf(vmin=vmin, vmax=vmax, levels=100, cmap='RdBu_r');"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e934e566-e821-479a-aa47-cc689ae04b94",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/binder/PACEL3_Chrol_a.ipynb
+++ b/binder/PACEL3_Chrol_a.ipynb
@@ -28,6 +28,93 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "91f4a31d-45da-4784-ab52-a9ea00f8cfed",
+   "metadata": {},
+   "source": [
+    "## Search for OPeNDAP URLs\n",
+    "\n",
+    "Will need the concept collection ID (ccid), or the DOI of the data of interest at a minimum.\n",
+    "\n",
+    "Can pass additional filters to narrow down the search, such as a time range, bounding box, etc.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "31f36503-fc59-4f29-bd27-765589bf3a68",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "PACE_ccid = \"C3620140256-OB_CLOUD\" # version 3.1 \n",
+    "time_range=[dt.datetime(2025, 1, 1), dt.datetime(2025, 3, 30)]\n",
+    "cmr_urls = get_cmr_urls(ccid=PACE_ccid, limit=1000, time_range=time_range) # limit by default = 50\n",
+    "\n",
+    "print(\"################################################ \\n We found a total of \", len(cmr_urls), \"OPeNDAP URLS!!!\\n################################################\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "48b42e8a-4aff-4761-887c-b41512530791",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cmr_urls[:5]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d3b57f78-82ab-4a72-8894-3315de591ce9",
+   "metadata": {},
+   "source": [
+    "## Identify only those granules associated with 4km resolution\n",
+    "\n",
+    "The CMR returns URLs that belong to different resolutions. We need to further filter these to that ALL urls point to a homogeneous resource.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8a61be5e-1255-43d4-ab7c-1c950c174e82",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "chlor_a_urls = [url for url in cmr_urls if \"DAY.CHL.V3_1.chlor_a.4km\" in url]\n",
+    "len(chlor_a_urls)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4085e72d-f963-4504-b84d-8224944b06cd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "chlor_a_urls[:5]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8fce82b9-a48f-40f6-8fbd-a4be6c67473f",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d8e45e61-896d-456e-9e0c-9e0b504b62da",
+   "metadata": {},
+   "source": [
+    "## EDL Authentication\n",
+    "\n",
+    "This is a necessary step to download any data, which includes metadata, from a remote file.\n",
+    "\n",
+    "There are many ways to authenticate with OPeNDAP in Python, below we use earthaccess as it can abstract the authentication to use tokens to retrieve data."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "5cda4b88-158c-4bea-915e-533806d6704d",
@@ -43,109 +130,38 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "b129b2c1-62bf-4971-b2ff-a1aa7fa6b49b",
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "e5989e77-94af-49f5-ab61-a4888d741776",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "PACE_ccid = \"C3620140256-OB_CLOUD\" # version 3.1 \n",
-    "time_range=[dt.datetime(2025, 1, 1), dt.datetime(2025, 3, 30)]\n",
-    "cmr_urls = get_cmr_urls(ccid=PACE_ccid, limit=1000, time_range=time_range) # limit by default = 50\n",
-    "\n",
-    "print(\"################################################ \\n We found a total of \", len(cmr_urls), \"OPeNDAP URLS!!!\\n################################################\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "b3bf3a43-4dc5-4284-a918-1d49fc80d033",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "cmr_urls[:5]"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "fc567b53-eede-4040-90c4-e6e9e56da269",
-   "metadata": {},
-   "source": [
-    "## Identify only those granules associated with 4km resolution\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "0d159096-1ec3-42c6-9141-2a834237e462",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "chlor_a_urls = [url for url in cmr_urls if \"DAY.CHL.V3_1.chlor_a.4km\" in url]\n",
-    "len(chlor_a_urls)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "46b9e504-bd01-4762-9d8c-09cd794f1afd",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "chlor_a_urls[0]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "ace96c16-5ee9-4763-8c59-0df94bdae83a",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "ds = open_url(chlor_a_urls[0], session=my_session, protocol=\"dap4\")\n",
-    "ds.tree()"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "id": "327c2d0b-d069-4943-8b33-3df54077a7b5",
    "metadata": {
     "tags": []
    },
    "source": [
-    "## Spatial subset\n",
-    "```\n",
+    "## Subset remote data \n",
+    "\n",
+    "Reading metadata from one granule within a Collection is important because it allows one to **identify variables of interest to subset by variable name**.\n",
+    "\n",
+    "OPeNDAP supports subsetting by variable names and by spatial subsets via the use of **Constraint Expressions**. PyDAP can construct DAP4 constraint expressions when the user provides a list of variable names and the dimension slices. As of now, identifying the spatial subset requires download coordinate data from remote granules. \n",
+    "\n",
+    "\n",
+    "###  Subset by Variable name: How to provide list of names for subset using the DAP4 protocol?\n",
+    "\n",
+    "Many of NASA files are hierarchical, meaning that there can be one of more Groups inside the file, and DAP4 fully supports it. \n",
+    "\n",
+    "What is a Group? A Group acts like a folder inside a computer filesystem, and to correctly identifying a variable by its name, one neeed to specify both path and name of the variable. This helps avoid **name collisions**. A name that integrates the full path to the variable is the `Fully Qualifying Name`.\n",
+    "\n",
+    "\n",
+    "### Subset by coordinate values\n",
+    "\n",
+    "Consider the case of an area of interest defined by bounding box with the following values (in python):\n",
+    "```python\n",
     "# Min/max of lon values\n",
     "minLon, maxLon = -96, 10\n",
     "\n",
     "# Min/Max of lat values\n",
     "minLat, maxLat = 6, 70\n",
-    "```"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "75c19911-d889-4e29-a965-1b7e4a299bdf",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "ds = xr.open_dataset(chlor_a_urls[0].replace(\"https\",\"dap4\"), session=my_session, engine='pydap')\n",
-    "ds"
+    "```\n",
+    "\n",
+    "With DAP4 protocol, one needs to download data and identify the indexes of the array. In python this is easy and is demonstrated below. \n"
    ]
   },
   {
@@ -155,6 +171,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "\n",
+    "# create an Xarray Dataset object. It eagerly downloads all dimension data, which in this case\n",
+    "# it facilitates our workflow since `latitude` & `longitude` are dimension data.\n",
+    "ds = xr.open_dataset(chlor_a_urls[0].replace(\"https\",\"dap4\"), session=my_session, engine='pydap')\n",
+    "\n",
+    "\n",
     "# Min/max of lon values\n",
     "minLon, maxLon = -96, 10\n",
     "# Min/Max of lat values\n",
@@ -162,8 +184,25 @@
     "\n",
     "lat, lon = ds['lat'].values, ds['lon'].values\n",
     "\n",
-    "iLon = np.where((lon>minLon)&(lon < maxLon))[0]\n",
-    "iLat= np.where((lat>minLat)&(lat < maxLat))[0]\n"
+    "# Identify ALL lat/lon data inside the bounding box\n",
+    "iLon = np.where((lon>minLon)&(lon < maxLon))[0] # 1D array\n",
+    "iLat= np.where((lat>minLat)&(lat < maxLat))[0] # 1D array\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "737b6c19-f4eb-41e1-ad9a-6a8b58fb6dc6",
+   "metadata": {},
+   "source": [
+    "### Define parameters to pass to pydap to stream data from remote OPeNDAP servers\n",
+    "\n",
+    "These are:\n",
+    "\n",
+    "1. List of OPeNDAP URLs.\n",
+    "2. `output_path`: Where the data will be stored.\n",
+    "3. `keep_variables`: A list of variables of interest. These will be downloaded. The variable names must be fully qualifying names.\n",
+    "4. `dim_slices`: This is a dictionary where the key is the dimension name (fully qualifying) and the values is a Tuple of first and last index. These together define the `slice` that will be applied to all relevant variables.\n",
+    "5. `session`: A (requests) session object that contains the EDL authentication information. This is the `my_session` object above. \n"
    ]
   },
   {
@@ -221,35 +260,6 @@
    "source": [
     "nds = xr.open_mfdataset(output_path+\"PACE_OCI.*.nc4\", concat_dim='time', parallel=True, combine=\"nested\")\n",
     "nds"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "6681e00c-8d7f-4263-b988-9b35a823c2dc",
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "f4adeda3-0818-48ae-8083-3a9183469533",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "vmin = ds['chlor_a'].attrs['display_min']\n",
-    "vmax = ds['chlor_a'].attrs['display_max']"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "2285766b-0d25-4c93-b082-cb1306bfbff0",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "chlor_a.plot.contourf(vmin=vmin, vmax=vmax, levels=100, cmap='RdBu_r');"
    ]
   },
   {

--- a/binder/PACEL3_Chrol_a.ipynb
+++ b/binder/PACEL3_Chrol_a.ipynb
@@ -1,0 +1,264 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "86c3306b-f706-4af3-96ee-6f45da34384a",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "# Accssing PACE data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "09bb36c1-66e0-4aee-ab08-e9a0e7ad2492",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import xarray as xr\n",
+    "import datetime as dt\n",
+    "import earthaccess\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "# import pydap-specific tools\n",
+    "from pydap.client import get_cmr_urls, open_url\n",
+    "from pydap.client import to_netcdf as dap_to_netcdf"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5cda4b88-158c-4bea-915e-533806d6704d",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "auth = earthaccess.login(strategy=\"netrc\", persist=True) # you will be promted to add your EDL credentials\n",
+    "\n",
+    "# pass Token Authorization to a new Session.\n",
+    "my_session = session=auth.get_session()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b129b2c1-62bf-4971-b2ff-a1aa7fa6b49b",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e5989e77-94af-49f5-ab61-a4888d741776",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "PACE_ccid = \"C3620140256-OB_CLOUD\" # version 3.1 \n",
+    "time_range=[dt.datetime(2025, 1, 1), dt.datetime(2025, 6, 30)]\n",
+    "cmr_urls = get_cmr_urls(ccid=PACE_ccid, limit=1000, time_range=time_range) # limit by default = 50\n",
+    "\n",
+    "print(\"################################################ \\n We found a total of \", len(cmr_urls), \"OPeNDAP URLS!!!\\n################################################\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b3bf3a43-4dc5-4284-a918-1d49fc80d033",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cmr_urls[:5]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fc567b53-eede-4040-90c4-e6e9e56da269",
+   "metadata": {},
+   "source": [
+    "## Identify only those granules associated with 4km resolution\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0d159096-1ec3-42c6-9141-2a834237e462",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "chlor_a_urls = [url for url in cmr_urls if \"DAY.CHL.V3_1.chlor_a.4km\" in url]\n",
+    "len(chlor_a_urls)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "327c2d0b-d069-4943-8b33-3df54077a7b5",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## Spatial subset\n",
+    "```\n",
+    "# Min/max of lon values\n",
+    "minLon, maxLon = -96, 10\n",
+    "\n",
+    "# Min/Max of lat values\n",
+    "minLat, maxLat = 6, 70\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "75c19911-d889-4e29-a965-1b7e4a299bdf",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "ds = xr.open_dataset(chlor_a_urls[0].replace(\"https\",\"dap4\"), session=my_session, engine='pydap')\n",
+    "ds"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c442ae81-572f-4c6d-9547-bb2cb0d75741",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Min/max of lon values\n",
+    "minLon, maxLon = -96, 10\n",
+    "# Min/Max of lat values\n",
+    "minLat, maxLat = 6, 70\n",
+    "\n",
+    "lat, lon = ds['lat'].values, ds['lon'].values\n",
+    "\n",
+    "iLon = np.where((lon>minLon)&(lon < maxLon))[0]\n",
+    "iLat= np.where((lat>minLat)&(lat < maxLat))[0]\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fe326d6c-dcbb-4f15-a76e-0b0a29462bc9",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "output_path = \"data/\"\n",
+    "\n",
+    "keep_variables = ['/lon', '/lat', \"/chlor_a\"]\n",
+    "dim_slices = {'/lat': (iLat[0], iLat[-1]), '/lon': (iLon[0], iLon[-1])}\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bdff1953-5676-4b27-9b96-500814e44f69",
+   "metadata": {},
+   "source": [
+    "## Stream data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9865c9c4-6f93-4a9b-a0a5-a6ccf24e4266",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "dap_to_netcdf(chlor_a_urls, session=my_session, keep_variables=keep_variables, dim_slices=dim_slices, output_path=output_path)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c283e719-4e24-4016-ba97-c3376d081cc1",
+   "metadata": {},
+   "source": [
+    "## inspect local files"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a2c2e44f-6671-4dc7-8146-5fe51f33a345",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds = xr.open_dataset(output_path+'PACE_OCI.20250301.L3m.DAY.CHL.V3_1.chlor_a.4km.nc4')\n",
+    "ds"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "49fda6ba-cfef-40c0-8546-a318f4cd9798",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8515f790-3c3b-4073-8f2d-2fad19d8f397",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "74949145-94c1-471d-bafe-9c222fb66e6d",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "nds = xr.open_mfdataset(output_path+\"PACE_OCI.*.nc4\", concat_dim='time', parallel=True, combine=\"nested\")\n",
+    "nds"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fbc004a3-2686-4f9e-8466-1efb287d4741",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/binder/PACEL3_Chrol_a.ipynb
+++ b/binder/PACEL3_Chrol_a.ipynb
@@ -98,6 +98,27 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "46b9e504-bd01-4762-9d8c-09cd794f1afd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "chlor_a_urls[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ace96c16-5ee9-4763-8c59-0df94bdae83a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds = open_url(chlor_a_urls[0], session=my_session, protocol=\"dap4\")\n",
+    "ds.tree()"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "327c2d0b-d069-4943-8b33-3df54077a7b5",
    "metadata": {
@@ -178,7 +199,7 @@
    "outputs": [],
    "source": [
     "%%time\n",
-    "dap_to_netcdf(chlor_a_urls, session=my_session, keep_variables=keep_variables, dim_slices=dim_slices, output_path=output_path)"
+    "dap_to_netcdf(chlor_a_urls[:10], session=my_session, keep_variables=keep_variables, dim_slices=dim_slices, output_path=output_path)"
    ]
   },
   {
@@ -186,7 +207,7 @@
    "id": "c283e719-4e24-4016-ba97-c3376d081cc1",
    "metadata": {},
    "source": [
-    "## inspect local files"
+    "## Inspect local files"
    ]
   },
   {
@@ -196,27 +217,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ds = xr.open_dataset(output_path+'PACE_OCI.20250301.L3m.DAY.CHL.V3_1.chlor_a.4km.nc4')\n",
+    "ds = xr.open_dataset(output_path+'PACE_OCI.20250101.L3m.DAY.CHL.V3_1.chlor_a.4km.nc4')\n",
     "ds"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "49fda6ba-cfef-40c0-8546-a318f4cd9798",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "ds"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "8515f790-3c3b-4073-8f2d-2fad19d8f397",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   },
   {
    "cell_type": "code",

--- a/binder/SWOT.ipynb
+++ b/binder/SWOT.ipynb
@@ -1,16 +1,13 @@
 {
  "cells": [
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "id": "82dd75ce-aead-479f-8e91-dd65b1d3401a",
    "metadata": {
     "tags": []
    },
-   "outputs": [],
    "source": [
-    "%load_ext autoreload\n",
-    "%autoreload 2"
+    "# Access SWOT Level 2 data with OPeNDAP"
    ]
   },
   {
@@ -31,6 +28,18 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "9a37c475-7be6-4e74-8058-fbc9a19fbbc3",
+   "metadata": {},
+   "source": [
+    "## Search for OPeNDAP URLs\n",
+    "\n",
+    "Will need the concept collection ID (ccid), or the DOI of the data of interest at a minimum.\n",
+    "\n",
+    "Can pass additional filters to narrow down the search, such as a time range, bounding box, etc.\n"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "28173d8b-7759-4d2a-b535-ecb043828a1c",
@@ -47,6 +56,18 @@
     "\n",
     "cmr_urls = get_cmr_urls(ccid=swot_ccid, bounding_box = bbox, time_range=time_range, limit=1000) # you can incread the limit of results\n",
     "print(\"################################################ \\n We found a total of \", len(cmr_urls), \"OPeNDAP URLS!!!\\n################################################\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "29ab03d0-dd5a-4288-9bd6-f6550da1dc6a",
+   "metadata": {},
+   "source": [
+    "## EDL Authentication\n",
+    "\n",
+    "This is a necessary step to download any data, which includes metadata, from a remote file.\n",
+    "\n",
+    "There are many ways to authenticate with OPeNDAP in Python, below we use earthaccess as it can abstract the authentication to use tokens to retrieve data."
    ]
   },
   {
@@ -71,7 +92,14 @@
    "source": [
     "### Read entire metadata\n",
     "\n",
-    "From one granule. This is important to identify variables of interested"
+    "Reading metadata from one granule within a Collection is important because it allows one to **identify variables of interest to subset by variable name**. OPeNDAP supports it via the use of Constraint Expressions. PyDAP can construct DAP4 constraint expressions when the user provides a list of variable names. \n",
+    "\n",
+    "### How to provide list of names for subset using the DAP4 protocol?\n",
+    "\n",
+    "Many of NASA files are hierarchical, meaning that there can be one of more Groups inside the file, and DAP4 fully supports it. \n",
+    "\n",
+    "What is a Group? A Group acts like a folder inside a computer filesystem, and to correctly identifying a variable by its name, one neeed to specify both path and name of the variable. This helps avoid **name collisions**. A name that integrates the full path to the variable is the `Fully Qualifying Name`.\n",
+    "\n"
    ]
   },
   {
@@ -153,7 +181,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dt1 = xr.open_datatree(output_path+f\"{cmr_urls[2].split('/')[-1]}.nc4\")"
+    "dt1 = xr.open_datatree(output_path+f\"{cmr_urls[0].split('/')[-1]}.nc4\")"
    ]
   },
   {
@@ -163,24 +191,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dt1.load()"
+    "dt1"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "fecbedd4-3ad9-47f7-bc32-97cb4265114a",
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "cbd040d2-dad2-4446-bb9d-992f4357c984",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   },
   {
    "cell_type": "code",

--- a/binder/SWOT.ipynb
+++ b/binder/SWOT.ipynb
@@ -8,7 +8,10 @@
     "tags": []
    },
    "outputs": [],
-   "source": []
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2"
+   ]
   },
   {
    "cell_type": "code",
@@ -36,7 +39,7 @@
    },
    "outputs": [],
    "source": [
-    "swot_ccid = \"C2799438313-POCLOUD\" #\n",
+    "swot_ccid = \"C2799438313-POCLOUD\"\n",
     "time_range = [dt.datetime(2023, 2, 1), dt.datetime(2023, 2, 12)] # One month of data\n",
     "\n",
     "# select a region in the Iceland-Faroe Ridge\n",
@@ -88,26 +91,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6e729ea5-022a-47d9-8281-d7c6b6bd4063",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "pyds[Variables[6]].dims"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "c227c98c-a48c-4076-8416-0466dbf92efa",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "Variables[6]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
    "id": "c76dbc9d-8481-4de8-8131-5833281c019e",
    "metadata": {
     "tags": []
@@ -115,11 +98,21 @@
    "outputs": [],
    "source": [
     "Variables = [\n",
-    "    \"/data_01/time\", \"/data_01/longitude\", \"/data_01/latitude\",\n",
-    "    \"/data_01/surface_classification_flag\", \"/data_01/ice_flag\",\n",
-    "    \"/data_01/mean_dynamic_topography\", \"/data_01/rain_flag\"\n",
+    "    \"/data_01/time\",\"/data_01/longitude\", \"/data_01/latitude\", \n",
+    "     \"/data_01/surface_classification_flag\", \"/data_01/ice_flag\",\n",
+    "     \"/data_01/mean_dynamic_topography\", \"/data_01/rain_flag\"\n",
     "]\n",
     "output_path = \"data/\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "15d43ed9-8f59-43d6-b07a-b8ce43c615fa",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Variables"
    ]
   },
   {
@@ -142,7 +135,7 @@
    "outputs": [],
    "source": [
     "%%time\n",
-    "dap_to_netcdf(cmr_urls[0], session=my_session, keep_variables=Variables, output_path=output_path)"
+    "dap_to_netcdf(cmr_urls[:20], session=my_session, keep_variables=Variables, output_path=output_path)"
    ]
   },
   {
@@ -160,53 +153,23 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dt = xr.open_datatree(output_path+f\"{cmr_url[0].split('/')[-1]}.nc4\")"
+    "dt1 = xr.open_datatree(output_path+f\"{cmr_urls[2].split('/')[-1]}.nc4\")"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6c9bcdfc-d35c-47be-a60b-5f0a524956a2",
-   "metadata": {
-    "tags": []
-   },
+   "id": "0e1b336f-511c-4cba-ba3a-6bbf767f1e26",
+   "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "dt1.load()"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "79872c5d-ceae-4805-b48d-94218cc95a7e",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "2ec02e49-ed70-4cf5-a436-4dd9b7da9b17",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "98332e3e-26a0-4696-b09c-9ed7985a4fac",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "aa1ad397-bab9-48ee-91d1-83f54ee3fbd0",
+   "id": "fecbedd4-3ad9-47f7-bc32-97cb4265114a",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -214,17 +177,15 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a922f575-9636-4da5-9ef4-adc007dcabe7",
-   "metadata": {
-    "tags": []
-   },
+   "id": "cbd040d2-dad2-4446-bb9d-992f4357c984",
+   "metadata": {},
    "outputs": [],
    "source": []
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "18e2cba0-a327-497e-b3f3-578c0da1696e",
+   "id": "9ed5821a-97fa-4ea3-b0f6-7620af68bcf2",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/binder/SWOT.ipynb
+++ b/binder/SWOT.ipynb
@@ -1,0 +1,254 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "82dd75ce-aead-479f-8e91-dd65b1d3401a",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e831a043-2dd7-4ad5-bbab-e2cb86cadc39",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import xarray as xr\n",
+    "import datetime as dt\n",
+    "import earthaccess\n",
+    "# import pydap-specific tools\n",
+    "from pydap.client import open_url,get_cmr_urls\n",
+    "from pydap.client import to_netcdf as dap_to_netcdf"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "28173d8b-7759-4d2a-b535-ecb043828a1c",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "swot_ccid = \"C2799438313-POCLOUD\" #\n",
+    "time_range = [dt.datetime(2023, 2, 1), dt.datetime(2023, 2, 12)] # One month of data\n",
+    "\n",
+    "# select a region in the Iceland-Faroe Ridge\n",
+    "bbox = [-20.760731,60.080727, -4.297294,65.675099] #[west, south, east, north]\n",
+    "\n",
+    "cmr_urls = get_cmr_urls(ccid=swot_ccid, bounding_box = bbox, time_range=time_range, limit=1000) # you can incread the limit of results\n",
+    "print(\"################################################ \\n We found a total of \", len(cmr_urls), \"OPeNDAP URLS!!!\\n################################################\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "088944f3-92dc-429b-88a3-993d8e253cc2",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "auth = earthaccess.login(strategy=\"netrc\", persist=True) # you will be promted to add your EDL credentials\n",
+    "\n",
+    "# pass Token Authorization to a new Session.\n",
+    "my_session=auth.get_session()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d4453bcb-4176-4f5e-b6d5-4780480e963d",
+   "metadata": {},
+   "source": [
+    "### Read entire metadata\n",
+    "\n",
+    "From one granule. This is important to identify variables of interested"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e51584a4-2276-4132-ba05-7b541e03b12d",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "pyds = open_url(cmr_urls[0], protocol=\"dap4\", session=my_session)\n",
+    "pyds.tree()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6e729ea5-022a-47d9-8281-d7c6b6bd4063",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pyds[Variables[6]].dims"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c227c98c-a48c-4076-8416-0466dbf92efa",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Variables[6]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c76dbc9d-8481-4de8-8131-5833281c019e",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "Variables = [\n",
+    "    \"/data_01/time\", \"/data_01/longitude\", \"/data_01/latitude\",\n",
+    "    \"/data_01/surface_classification_flag\", \"/data_01/ice_flag\",\n",
+    "    \"/data_01/mean_dynamic_topography\", \"/data_01/rain_flag\"\n",
+    "]\n",
+    "output_path = \"data/\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "80dadd83-e736-4983-ba70-fc9c4192f639",
+   "metadata": {},
+   "source": [
+    "# Download all data\n",
+    "\n",
+    "Stream each remote file into its own local file, downloading only the data of interest"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8a52d47d-f8fb-42bc-876a-51b60b3bd948",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "dap_to_netcdf(cmr_urls[0], session=my_session, keep_variables=Variables, output_path=output_path)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "59955861-d445-4547-a1e7-695e9fdf140a",
+   "metadata": {},
+   "source": [
+    "# Inspect a local file"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "686575ba-050d-49d7-b48c-eebb81ebb0f2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dt = xr.open_datatree(output_path+f\"{cmr_url[0].split('/')[-1]}.nc4\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6c9bcdfc-d35c-47be-a60b-5f0a524956a2",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "79872c5d-ceae-4805-b48d-94218cc95a7e",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2ec02e49-ed70-4cf5-a436-4dd9b7da9b17",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "98332e3e-26a0-4696-b09c-9ed7985a4fac",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "aa1ad397-bab9-48ee-91d1-83f54ee3fbd0",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a922f575-9636-4da5-9ef4-adc007dcabe7",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "18e2cba0-a327-497e-b3f3-578c0da1696e",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/binder/TEMPO_L3.ipynb
+++ b/binder/TEMPO_L3.ipynb
@@ -301,7 +301,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.12"
+   "version": "3.12.13"
   }
  },
  "nbformat": 4,

--- a/binder/TEMPO_NRT.ipynb
+++ b/binder/TEMPO_NRT.ipynb
@@ -1,0 +1,292 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "dd1d5518-f9a5-4a7f-a5fc-16d6a7394ee4",
+   "metadata": {},
+   "source": [
+    "<span style='color:#0066cc'> <span style='font-family:serif'> <font size=\"15\"> **Accessing TEMPO NRT (Level 2)**\n",
+    "\n",
+    "\n",
+    "\n",
+    " <span style='color:#ff6666'><font size=\"5\"> **Requirements**\n",
+    "1. <font size=\"3\"> EDL authentication (username/password)\n",
+    "2. <font size=\"3\"> Generate a Bearer Token.\n",
+    "4. <font size=\"3\"> Get `environment.yml` file and install conda environment to run notebook.\n",
+    "\n",
+    "\n",
+    " <span style='color:#ff6666'><font size=\"5\"> **Objectives**\n",
+    "\n",
+    "### Subset a remote file\n",
+    "\n",
+    "- <font size=\"3\">**a)** By Variables\n",
+    "- <font size=\"3\">**b)** By Spatial selection\n",
+    "\n",
+    "### Subset multiple remote files\n",
+    "\n",
+    "- <font size=\"3\">Stream subset of data\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "740c000d-5314-4aaf-81a5-d70d1e79f9fe",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import xarray as xr\n",
+    "import datetime as dt\n",
+    "import earthaccess\n",
+    "import pydap\n",
+    "import matplotlib.pyplot as plt\n",
+    "# import pydap-specific tools\n",
+    "from pydap.net import create_session\n",
+    "from pydap.client import get_cmr_urls, open_url\n",
+    "from pydap.client import to_netcdf as dap_to_netcdf"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f358904c-f969-43c4-93ce-4d137c0492c8",
+   "metadata": {},
+   "source": [
+    "# Finding OPeNDAP URLs\n",
+    "\n",
+    "<span style='font-family:serif'> <font size=\"5.5\"><span style='color:#0066cc'> **Query opendap urls using NASA's CMR API**\n",
+    "    \n",
+    "    \n",
+    "We are interested in `TEMPO NO2 tropospheric and stratospheric columns V04` data. This collection provides hourly data for level 2 data, considered Near Real Time (NRT).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c7bdc702-f426-4b0a-a49f-2649ecdc7c18",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "TEMPO_L2_NRTNO2_ccid = \"C3685896872-LARC_CLOUD\" # \n",
+    "time_range = [dt.datetime(2025, 10, 1), dt.datetime(2025, 10, 7)] # One month of data\n",
+    "\n",
+    "bounding_box = [-124.63309,46.35932,  -121, 49.83307] # WSEN area within Seattle PNW\n",
+    "\n",
+    "cmr_urls = get_cmr_urls(ccid=TEMPO_L2_NRTNO2_ccid, bounding_box=bounding_box, time_range=time_range, limit=1000) # you can incread the limit of results\n",
+    "\n",
+    "print(\"################################################ \\n We found a total of \", len(cmr_urls), \"OPeNDAP URLS!!!\\n################################################\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f9ea1330-8390-4ae2-b580-45f039bf9aa6",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "cmr_urls[0]\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6e04deee-6c59-4437-9aed-381a73085496",
+   "metadata": {},
+   "source": [
+    "<span style='font-family:serif'> <font size=\"5.5\"><span style='color:#0066cc'> **EDL Authentication via OPeNDAP**\n",
+    "\n",
+    "<font size=\"3.5\"> You can authenticate via:\n",
+    "\n",
+    "* <font size=\"3.5\"> `.netrc` file (username password)\n",
+    "* <font size=\"3.5\"> Token bearer header\n",
+    "\n",
+    "\n",
+    "<font size=\"3.5\"> OPeNDAP's Hyrax server support both forms of authentication. Below we demonstrate using earthaccess to store and inherit EDL credentials into a session that will be used to stream data from OPeNDAP in the Cloud.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2725988f-618e-4ed4-879c-3adc0c4771e4",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "auth = earthaccess.login(strategy=\"netrc\", persist=True) # you will be promted to add your EDL credentials\n",
+    "\n",
+    "# pass Token Authorization to a new Session.\n",
+    "my_session = session=auth.get_session()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a2322093-b9b6-49c5-8bb4-7ad17bffb95d",
+   "metadata": {},
+   "source": [
+    "# Accessing Metadata\n",
+    "\n",
+    "<font size=\"3.5\"> What are some tools, their differences, and what do they do.\n",
+    "\n",
+    "<span style='font-family:serif'> <font size=\"5.5\"><span style='color:#0066cc'> **PYDAP: Metadata-Only**\n",
+    "\n",
+    "\n",
+    "\n",
+    "```{note}\n",
+    "Q: How do we tell the server which protocol to use?\n",
+    "A: By replaing the http -> dap4 in the URL\n",
+    "```\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "58f75519-3de3-40ab-8591-b77b6ace0772",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "pyds = open_url(cmr_urls[0], protocol=\"dap4\", session=my_session)\n",
+    "pyds.tree()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4510032f-11c6-4dc4-ba8a-0631f2ab2aef",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2025-12-13T05:44:16.286695Z",
+     "iopub.status.busy": "2025-12-13T05:44:16.286267Z",
+     "iopub.status.idle": "2025-12-13T05:44:16.309833Z",
+     "shell.execute_reply": "2025-12-13T05:44:16.308986Z",
+     "shell.execute_reply.started": "2025-12-13T05:44:16.286661Z"
+    },
+    "tags": []
+   },
+   "source": [
+    "### Subset by Variables\n",
+    "\n",
+    "We will retain `xtrack`, and all data within Groups `product` and `geolocation`\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5b87a6c6-6bb3-4c3b-b1a1-2f61c8ff5eea",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "output_path = \"data/\"\n",
+    "\n",
+    "keep_variables = [\"/xtrack\",\"/mirror_step\", \n",
+    "                  \"/product\", \"/geolocation/time\",\n",
+    "                  \"/geolocation/longitude\",\"/geolocation/latitude\", \n",
+    "                 ]\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ca68ec34-eea8-4984-8eb5-e56eb627314b",
+   "metadata": {},
+   "source": [
+    "# Stream data\n",
+    "\n",
+    "each remote file is stored into an individual file. No data aggregation\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6140bbc9-4eec-402c-b780-747adb272ea9",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "dap_to_netcdf(cmr_urls, session=my_session, keep_variables=keep_variables, output_path=output_path)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8093919a-6b92-494b-91d6-0f8247819616",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "dt = xr.open_datatree(output_path+\"TEMPO_NO2_L2_V04_20251001T141426Z_S004G08.nc4\")\n",
+    "dt['geolocation'].load()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e99e3954-116e-4ea0-867e-256cacd6be8f",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "dt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "85d74ae8-2d3d-462c-91d1-23da42ef1833",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "81689feb-fa7e-41ab-a479-a794f4c7490d",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "644a6549-5fa3-4a38-8a16-19341e0812f9",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -16,10 +16,11 @@ dependencies:
 - scipy
 - xoak
 - xarray = 2026.1
-- pydap = 3.5.9
 - pip:
   - jupyter-contrib-nbextensions
   - ipywidgets 
   - widgetsnbextension
+  - git+https://github.com/pydap/pydap.git
+
 
 

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -15,7 +15,7 @@ dependencies:
 - pandas
 - scipy
 - xoak
-- xarray = 2024.6.0
+- xarray = 2026.1
 - pydap = 3.5.9
 - pip:
   - jupyter-contrib-nbextensions


### PR DESCRIPTION
Last PR, declared a conda environment that pinned xarray=2024.6 which is too old and not good ha! That version of Xarray does not have the changes I have introduced to Xarray. 

This PR
- [x] Updates (and pins) the version of Xarray to a recent 2026.1 version released a few months ago.
- [x] Removes unused line of code from tutorial. 
- [x] Adds more tutorial examples
