### PR TITLE
remove some deprecated jupyter dependencies

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -13,6 +13,7 @@ dependencies:
 - tqdm
 - dask
 - pandas
+- notebook < 7.0
 - scipy
 - xoak
 - pyresample
@@ -22,6 +23,3 @@ dependencies:
   - ipywidgets 
   - widgetsnbextension
   - git+https://github.com/pydap/pydap.git
-
-
-


### PR DESCRIPTION
There is an issue with binder - it may be about the extensions that were deprecated. This PR isolates `environment.yml` changes in #23 