### PR TITLE
update environment.yml

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -1,25 +1,25 @@
 name: Earthdata2026
 channels:
-- conda-forge
+  - conda-forge
 dependencies:
-- pip
-- numpy
-- python = 3.12
-- netCDF4
-- matplotlib
-- jupyterlab
-- cartopy
-- earthaccess
-- tqdm
-- dask
-- pandas
-- notebook < 7.0
-- scipy
-- xoak
-- pyresample
-- xarray = 2026.1
-- pip:
-  - jupyter-contrib-nbextensions
-  - ipywidgets 
-  - widgetsnbextension
-  - git+https://github.com/pydap/pydap.git
+  - python=3.12
+  - pip
+  - libsqlite
+  - numpy
+  - netCDF4
+  - matplotlib
+  - jupyterlab
+  - jupyter_server
+  - jupyterhub-singleuser
+  - cartopy
+  - earthaccess
+  - ipywidgets
+  - tqdm
+  - dask
+  - pandas
+  - scipy
+  - xoak
+  - pyresample
+  - xarray=2026.1
+  - pip:
+      - git+https://github.com/pydap/pydap.git


### PR DESCRIPTION
This PR (hopefully) enables the Binder to launch. 

Locally without updating the environment I could not launch the binder. The error I waas getting was:
```python
from pysqlite2 import dbapi2 as sqlite3 # type:ignore[no-redef] ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ 
ModuleNotFoundError: No module named 'pysqlite2' CONTAINER FINISHED RUNNING.
``` 

I updated the environment and now it launches and notebooks run. Perhaps fixing the local issue solves the remote BinderHub issue too.